### PR TITLE
Create dedicated particle list action service for the VD FD 

### DIFF
--- a/dunesim/Simulation/larg4services_dune.fcl
+++ b/dunesim/Simulation/larg4services_dune.fcl
@@ -118,6 +118,9 @@ dune_particle_list_action:
                              # --- This forces that true penultimate point to be saved, thus preserving the info
 }
 
+dunefdvd_particle_list_action: @local::dune_particle_list_action
+dunefdvd_particle_list_action.keepEMShowerDaughters: false  #roll up the shower children into the primary parent
+
 
 supernova_particle_list_action: @local::dune_particle_list_action
 supernova_particle_list_action.keepGenTrajectories: ["marley"]


### PR DESCRIPTION
The dedicated service block disables keeping the shower children.

Sibling PR: https://github.com/DUNE/dunecore/pull/4