### PR TITLE
Modules/servcies for unique noise per channel and updates/fixes for NuEScatterGen

### DIFF
--- a/dunesim/DetSim/Module/SimWireClnSigDUNE_module.cc
+++ b/dunesim/DetSim/Module/SimWireClnSigDUNE_module.cc
@@ -1,0 +1,365 @@
+// SimWireClnSigDUNE_module.cc (modified version of SimWireDUNE_module.cc,
+//
+// David Adams
+// December 2015
+//
+// SimWireDUNE class designed to simulate signal on a wire in the TPC
+//
+// Developed from the now-obsolete SimWireDUNE35t_module.cc. This implementation
+// follows the TSI model where most of the algorithmic code is moved to
+// services accessed via service interfaces.
+//
+// For configuration parameters, see the "Flags" block in the module class
+// definition below. Remove the leading "f" to get the parameter name.
+//
+// There is no flag for compression because this must always be invoked
+// to apply zero suppression. Use ReplaceCompressService (prolog cmpreplace)
+// to effectively skip the compression while retaining the supression.
+//
+// The interface names for the accessed services are listed in the "Services"
+// block in the header below.
+//
+// Some useful module and service configurations may be found in
+// detsimmodules_dune.fcl, e.g. cmpreplace to skip compression.
+//
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Mike Wang
+// September 2021
+//
+// This version (SimWireClnSigDUNE) keeps both the signal+noise and pure signal
+// waveforms. For this version, please do the following in the fcl file:
+//
+// (a) set the NoiseScale for the PedestalAdditionService to 0
+// (b) set DistortOn in the daq section to "false"
+// (c) remember to set fSuppressUsingClnSig to true if doing zero suppresion
+//     based on clean signal
+//
+
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iostream>
+
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include "lardataobj/RawData/raw.h"
+#include "larcore/Geometry/Geometry.h"
+#include "lardataobj/Simulation/sim.h"
+#include "lardataobj/Simulation/SimChannel.h"
+#include "lardataobj/RawData/RawDigit.h"
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+
+#include "dunecore/ArtSupport/DuneToolManager.h"
+
+#include "dunecore/DuneInterface/Data/AdcTypes.h"
+#include "dunecore/DuneInterface/Data/AdcSimulator.h"
+#include "dunecore/DuneInterface/Service/AdcSuppressService.h"
+#include "dunecore/DuneInterface/Service/AdcCompressService.h"
+#include "dunecore/DuneInterface/Service/SimChannelExtractService.h"
+#include "dunecore/DuneInterface/Service/UniqChannelNoiseService.h"
+#include "dunecore/DuneInterface/Service/PedestalAdditionService.h"
+#include "dunecore/DuneInterface/Service/AdcDistortionService.h"
+
+using std::ostringstream;
+using std::cout;
+using std::endl;
+using std::string;
+
+//**********************************************************************
+
+// Base class for creation of raw signals on wires.
+class SimWireClnSigDUNE : public art::EDProducer {
+
+public:
+
+  explicit SimWireClnSigDUNE(fhicl::ParameterSet const& pset);
+  virtual ~SimWireClnSigDUNE();
+
+  // read/write access to event
+  void produce (art::Event& evt);
+  void beginJob();
+  void endJob();
+  void reconfigure(fhicl::ParameterSet const& p);
+
+private:
+
+  std::string fSimChannelLabel; ///< Data product holding the ionization electrons
+
+  // Flags.
+  bool fNoiseOn;           ///< noise turned on or off for debugging; default is on
+  bool fPedestalOn;        ///< switch for simulation of nonzero pedestals
+  bool fDistortOn;         ///< switch for simulation of stuck bits
+  bool fSuppressOn;        ///< switch for simulation of zero suppression
+  bool fSuppressUsingClnSig; ///< do zs based on clean signal
+  bool fKeepEmptyChannels; ///< Write out empty channels iff true.
+  // Tools.
+  std::string fAdcSimulatorName;
+
+
+  std::unique_ptr<AdcSimulator> m_pads;
+
+  // Services.
+  art::ServiceHandle<geo::Geometry> m_pgeo;
+  art::ServiceHandle<AdcSuppressService> m_pzs;
+  art::ServiceHandle<AdcCompressService> m_pcmp;
+  art::ServiceHandle<SimChannelExtractService> m_pscx;
+  art::ServiceHandle<UniqChannelNoiseService> m_pcns;
+  art::ServiceHandle<AdcDistortionService> m_pdis;
+  art::ServiceHandle<PedestalAdditionService> m_ppad;
+
+}; // class SimWireClnSigDUNE
+
+DEFINE_ART_MODULE(SimWireClnSigDUNE)
+
+//**********************************************************************
+
+SimWireClnSigDUNE::SimWireClnSigDUNE(fhicl::ParameterSet const& pset) : EDProducer{pset} {
+  reconfigure(pset);
+  produces< std::vector<raw::RawDigit> >();
+  produces< std::vector<raw::RawDigit> >("signal");
+}
+
+//**********************************************************************
+
+SimWireClnSigDUNE::~SimWireClnSigDUNE() { }
+
+//**********************************************************************
+
+void SimWireClnSigDUNE::reconfigure(fhicl::ParameterSet const& p) {
+  string myname = "SimWireClnSigDUNE::reconfigure: ";
+  string myprefix = myname + "    ";
+  fSimChannelLabel   = p.get<std::string>("SimChannelLabel");
+  fNoiseOn           = p.get<bool>("NoiseOn");
+  fPedestalOn        = p.get<bool>("PedestalOn");
+  fDistortOn         = p.get<bool>("DistortOn");
+  fSuppressOn        = p.get<bool>("SuppressOn");
+  fSuppressUsingClnSig = p.get<bool>("SuppressUsingClnSig", false);
+  fKeepEmptyChannels = p.get<bool>("KeepEmptyChannels");
+  fAdcSimulatorName = p.get<string>("AdcSimulator");
+
+  DuneToolManager* pdtm = DuneToolManager::instance();
+  m_pads = pdtm == nullptr ? nullptr : pdtm->getPrivate<AdcSimulator>(fAdcSimulatorName);
+  ostringstream out;
+  out << myname << "Tools:" << endl;
+  out << "  AdcSimulator: " << bool(m_pads) << endl;
+  out << myname << "Accessed services:" << endl;
+  out << myname << "  SimChannel extraction service:" << endl;
+  m_pscx->print(out, myprefix) << endl;
+  if ( fNoiseOn ) {
+    out << myname << "  Channel noise service:" << endl;;
+    m_pcns->print(out, myprefix);
+  } else {
+    out << myname << "  Channel noise is off.";
+  }
+  out << endl;
+  if ( fPedestalOn ) {
+    out << myname << "  Pedestal addition service:" << endl;;
+    m_ppad->print(out, myprefix);
+  } else {
+    out << myname << "  Pedestal addition is off.";
+  }
+  out << endl;
+  if ( fDistortOn ) {
+    out << myname << "  ADC distortion service:" << endl;;
+    m_pdis->print(out, myprefix);
+  } else {
+    out << myname << "  ADC distortion is off.";
+  }
+  out << endl;
+  if ( fSuppressOn ) {
+    out << myname << "  ADC suppression service:" << endl;
+    m_pzs->print(out, myprefix);
+  } else {
+    out << myname << "  ADC suppression is off.";
+  }
+  out << endl;
+  out << myname << "  Compression service:" << endl;
+  out << endl;
+  m_pcmp->print(out, myprefix);
+  out << myname << "  KeepEmptyChannels:" << fKeepEmptyChannels << endl;
+  mf::LogInfo("SimWireClnSigDUNE::reconfigure") << out.str();
+
+  return;
+}
+
+//**********************************************************************
+
+void SimWireClnSigDUNE::beginJob() { }
+
+//**********************************************************************
+
+void SimWireClnSigDUNE::endJob() { }
+
+//**********************************************************************
+
+void SimWireClnSigDUNE::produce(art::Event& evt) {
+  const string myname = "SimWireClnSigDUNE::produce: ";
+
+  // Unlike in the standard SimWireDUNE_module, in this "ClnSig"
+  // version, we do not create a vector of sim::SimChannel* that
+  // has the same number of entries as the number of detector 
+  // channels.  This is because we only loop through SimChannels
+  // that have signal in them.
+  std::vector<const sim::SimChannel*> chanHandle;
+  std::map<unsigned int, unsigned int> WGrp2NoiseMap;
+  unsigned int ncohnoise = 0;
+  evt.getView(fSimChannelLabel, chanHandle);
+  for ( size_t c=0; c<chanHandle.size(); ++c ) {
+    unsigned int wgrp = m_pcns->getGroupNumberFromOfflineChannel(chanHandle[c]->Channel());
+    auto [itwgn, newpair ] = WGrp2NoiseMap.insert(std::map<unsigned int, unsigned int>::value_type(wgrp, ncohnoise));
+    if ( newpair ) ncohnoise++;
+  }
+  // Let channel noise service know how many array points to generate
+  m_pcns->setNumNoiseArrayPoints(chanHandle.size(), ncohnoise);
+
+  // make an unique_ptr of sim::SimDigits that allows ownership of the produced
+  // digits to be transferred to the art::Event after the put statement below
+  std::unique_ptr<std::vector<raw::RawDigit>>  digcol(new std::vector<raw::RawDigit>);
+  std::unique_ptr<std::vector<raw::RawDigit>>  digcol2(new std::vector<raw::RawDigit>);
+
+  // Fetch the number of ticks to write out for each channel.
+  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
+  auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clockData);
+  unsigned int nTickReadout  = detProp.ReadOutWindowSize();
+  m_pcns->newEvent(); // all unique noise waveforms will be pre-generated here
+  // Loop over SimChannels (i.e. ignore channels with no deposited charge).
+  std::map<int,double>::iterator mapIter;
+  for ( size_t c=0; c<chanHandle.size(); ++c ) {
+
+    // Get the SimChannel for this channel
+    const sim::SimChannel* psc = chanHandle[c];
+    unsigned int chan = chanHandle[c]->Channel();
+
+    // Create vector that holds the floating ADC count for each tick.
+    std::vector<AdcSignal> fChargeWork;
+
+    // Extract the floating ADC count from the SimChannel for each tick in the channel.
+    m_pscx->extract(clockData, psc, fChargeWork);
+
+    // Make a copy to store pure signal
+    std::vector<AdcSignal> fChargeWork2(fChargeWork);
+
+    // Add noise to each tick in the channel.
+    if ( fNoiseOn ) {
+      unsigned int wgrp = m_pcns->getGroupNumberFromOfflineChannel(chan);
+      m_pcns->setIdxNoiseArrayPoints(c, WGrp2NoiseMap[wgrp]);
+      m_pcns->addNoise(clockData, detProp, chan, fChargeWork);
+    }
+
+    // Option to display signals before adding pedestals.
+    // E.g. logsig = chan==1000.
+    bool logsig = false;
+    if ( logsig ) {
+      cout << myname << "Signals after noise:" << endl;
+      for ( unsigned int itck=0; itck<fChargeWork.size(); ++itck ) {
+        if(fChargeWork[itck] > 0 )
+          cout << myname << " " << itck << ": chg=" << fChargeWork[itck] << endl;
+      }
+    }
+
+    // Add pedestal.
+    float pedval = 0.0; // Pedestal to be recorded in RawDigits collection
+    float pedrms = 0.0; // Pedestal RMS to be recorded in RawDigits collection
+    if ( fPedestalOn ) {
+      m_ppad->addPedestal(chan, fChargeWork, pedval, pedrms);
+      m_ppad->addPedestal(chan, fChargeWork2, pedval, pedrms);
+    }
+
+    // Convert floating ADC to integral ADC count.
+    std::vector<short> adcvec(fChargeWork.size(), 0);
+    std::vector<short> adcvec2(fChargeWork2.size(), 0);
+    const short adcmax = 4095;
+    for ( unsigned int itck=0; itck<fChargeWork.size(); ++itck ) {
+
+      AdcSignal adcin = fChargeWork[itck];
+      AdcSignal adcin2 = fChargeWork2[itck];
+      short adc = 0;
+      short adc2 = 0;
+      bool useOldAdc = false;
+      // New ADC calculation (with tool).
+      if ( m_pads ) {
+        if(adcin > 0)
+          //cout << " adcin " << adcin << endl;
+        adc = m_pads->count(adcin, chan);
+        adc2 = m_pads->count(adcin2, chan);
+      } else {
+        //cout << myname << "WARNING: AdcSimulator not found." << endl;
+        useOldAdc = true;
+      }
+      // Old ADC calculation.
+      if ( useOldAdc ) {
+        short adci = 0;
+        if ( adcin > 0 ) adci = (short) (adcin + 0.5);
+        if ( adci > adcmax ) adci = adcmax;
+        bool show = m_pads && adci != adc;
+
+        static int ndump = 1000;
+        if ( ndump && show ) {
+          cout << myname << "  ADC: " << adci << " --> " << adc << " (" << adcin << ")" << endl;
+          --ndump;
+        }
+        adc = adci;
+
+        // do the same for pure signal
+        adci = 0;
+        if ( adcin2 > 0 ) adci = (short) (adcin2 + 0.5);
+        if ( adci > adcmax ) adci = adcmax;
+        adc2 = adci;
+      }
+      // Record the ADC value.
+      adcvec[itck] = adc;
+      adcvec2[itck] = adc2;
+    }
+    // Resize to the correct number of time samples, dropping extra samples.
+    adcvec.resize(nTickReadout);
+    adcvec2.resize(nTickReadout);
+
+    // Add stuck bits.
+    if ( fDistortOn ) {
+      m_pdis->modify(chan, adcvec);
+    }
+
+    // Zero suppress.
+    std::vector<short> vadc;
+    if ( fSuppressUsingClnSig ) {   
+      vadc = adcvec2;
+    } else {
+      vadc = adcvec;
+    }
+    AdcCountSelection acs(vadc, chan, pedval);
+    if ( fSuppressOn ) {
+      m_pzs->filter(acs);
+    }
+    int nkeep = 0;
+    for ( bool kept : acs.filter ) if ( kept ) ++nkeep;
+
+    // If flag is not set and channel is empty, skip it.
+    if ( ! fKeepEmptyChannels && nkeep==0 ) continue;
+
+    // Compress.
+    raw::Compress_t comp = raw::kNone;
+    m_pcmp->compress(adcvec, acs.filter, pedval, comp);
+    m_pcmp->compress(adcvec2, acs.filter, pedval, comp);
+
+    // Create and store raw digit.
+    raw::RawDigit rd(chan, nTickReadout, adcvec, comp);
+    rd.SetPedestal(pedval, pedrms);
+    digcol->push_back(rd);            // add this digit to the collection
+
+    raw::RawDigit rd2(chan, nTickReadout, adcvec2, comp);
+    rd2.SetPedestal(pedval, pedrms);
+    digcol2->push_back(rd2);            // add this digit to the collection
+
+  }  // end loop over channels
+
+  evt.put(std::move(digcol));
+  evt.put(std::move(digcol2),"signal");
+
+}

--- a/dunesim/DetSim/Module/SimWireUniqNoiseDUNE_module.cc
+++ b/dunesim/DetSim/Module/SimWireUniqNoiseDUNE_module.cc
@@ -1,0 +1,330 @@
+// SimWireUniqNoiseDUNE_module.cc
+//
+// David Adams
+// December 2015
+//
+// SimWireDUNE class designed to simulate signal on a wire in the TPC
+//
+// Developed from the now-obsolete SimWireDUNE35t_module.cc. This implementation
+// follows the TSI model where most of the algorithmic code is moved to
+// services accessed via service interfaces.
+//
+// For configuration parameters, see the "Flags" block in the module class
+// definition below. Remove the leading "f" to get the parameter name.
+//
+// There is no flag for compression because this must always be invoked
+// to apply zero suppression. Use ReplaceCompressService (prolog cmpreplace)
+// to effectively skip the compression while retaining the supression.
+//
+// The interface names for the accessed services are listed in the "Services"
+// block in the header below.
+//
+// Some useful module and service configurations may be found in
+// detsimmodules_dune.fcl, e.g. cmpreplace to skip compression.
+
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iostream>
+
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include "lardataobj/RawData/raw.h"
+#include "larcore/Geometry/Geometry.h"
+#include "lardataobj/Simulation/sim.h"
+#include "lardataobj/Simulation/SimChannel.h"
+#include "lardataobj/RawData/RawDigit.h"
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+
+#include "dunecore/ArtSupport/DuneToolManager.h"
+
+#include "dunecore/DuneInterface/Data/AdcTypes.h"
+#include "dunecore/DuneInterface/Data/AdcSimulator.h"
+#include "dunecore/DuneInterface/Service/AdcSuppressService.h"
+#include "dunecore/DuneInterface/Service/AdcCompressService.h"
+#include "dunecore/DuneInterface/Service/SimChannelExtractService.h"
+#include "dunecore/DuneInterface/Service/UniqChannelNoiseService.h"
+#include "dunecore/DuneInterface/Service/PedestalAdditionService.h"
+#include "dunecore/DuneInterface/Service/AdcDistortionService.h"
+
+using std::ostringstream;
+using std::cout;
+using std::endl;
+using std::string;
+
+//**********************************************************************
+
+// Base class for creation of raw signals on wires.
+class SimWireUniqNoiseDUNE : public art::EDProducer {
+
+public:
+
+  explicit SimWireUniqNoiseDUNE(fhicl::ParameterSet const& pset);
+  virtual ~SimWireUniqNoiseDUNE();
+
+  // read/write access to event
+  void produce (art::Event& evt);
+  void beginJob();
+  void endJob();
+  void reconfigure(fhicl::ParameterSet const& p);
+
+private:
+
+  std::string fSimChannelLabel; ///< Data product holding the ionization electrons
+
+  // Flags.
+  bool fNoiseOn;           ///< noise turned on or off for debugging; default is on
+  bool fPedestalOn;        ///< switch for simulation of nonzero pedestals
+  bool fDistortOn;         ///< switch for simulation of stuck bits
+  bool fSuppressOn;        ///< switch for simulation of zero suppression
+  bool fKeepEmptyChannels; ///< Write out empty channels iff true.
+  bool fUseRawDigitInput;  ///< Use (presumably noise-free) RawDigits for input instead of SimChannels
+  std::string fRawDigitInputLabel; ///< The module label for the RawDigits to read in
+  // Tools.
+  std::string fAdcSimulatorName;
+
+
+  std::unique_ptr<AdcSimulator> m_pads;
+
+  // Services.
+  art::ServiceHandle<geo::Geometry> m_pgeo;
+  art::ServiceHandle<AdcSuppressService> m_pzs;
+  art::ServiceHandle<AdcCompressService> m_pcmp;
+  art::ServiceHandle<SimChannelExtractService> m_pscx;
+  art::ServiceHandle<UniqChannelNoiseService> m_pcns;
+  art::ServiceHandle<AdcDistortionService> m_pdis;
+  art::ServiceHandle<PedestalAdditionService> m_ppad;
+
+}; // class SimWireUniqNoiseDUNE
+
+DEFINE_ART_MODULE(SimWireUniqNoiseDUNE)
+
+//**********************************************************************
+
+SimWireUniqNoiseDUNE::SimWireUniqNoiseDUNE(fhicl::ParameterSet const& pset) : EDProducer{pset} {
+  reconfigure(pset);
+  produces< std::vector<raw::RawDigit> >();
+}
+
+//**********************************************************************
+
+SimWireUniqNoiseDUNE::~SimWireUniqNoiseDUNE() { }
+
+//**********************************************************************
+
+void SimWireUniqNoiseDUNE::reconfigure(fhicl::ParameterSet const& p) {
+  string myname = "SimWireUniqNoiseDUNE::reconfigure: ";
+  string myprefix = myname + "    ";
+  fSimChannelLabel   = p.get<std::string>("SimChannelLabel");
+  fNoiseOn           = p.get<bool>("NoiseOn");
+  fPedestalOn        = p.get<bool>("PedestalOn");
+  fDistortOn         = p.get<bool>("DistortOn");
+  fSuppressOn        = p.get<bool>("SuppressOn");
+  fKeepEmptyChannels = p.get<bool>("KeepEmptyChannels");
+  fUseRawDigitInput  = p.get<bool>("UseRawDigitInput", false);
+  fRawDigitInputLabel= p.get<string>("RawDigitInputLabel", "");
+  fAdcSimulatorName = p.get<string>("AdcSimulator");
+
+  DuneToolManager* pdtm = DuneToolManager::instance();
+  m_pads = pdtm == nullptr ? nullptr : pdtm->getPrivate<AdcSimulator>(fAdcSimulatorName);
+  ostringstream out;
+  out << myname << "Tools:" << endl;
+  out << "  AdcSimulator: " << bool(m_pads) << endl;
+  out << myname << "Accessed services:" << endl;
+  out << myname << "  SimChannel extraction service:" << endl;
+  m_pscx->print(out, myprefix) << endl;
+  if ( fNoiseOn ) {
+    out << myname << "  Channel noise service:" << endl;;
+    m_pcns->print(out, myprefix);
+  } else {
+    out << myname << "  Channel noise is off.";
+  }
+  out << endl;
+  if ( fPedestalOn ) {
+    out << myname << "  Pedestal addition service:" << endl;;
+    m_ppad->print(out, myprefix);
+  } else {
+    out << myname << "  Pedestal addition is off.";
+  }
+  out << endl;
+  if ( fDistortOn ) {
+    out << myname << "  ADC distortion service:" << endl;;
+    m_pdis->print(out, myprefix);
+  } else {
+    out << myname << "  ADC distortion is off.";
+  }
+  out << endl;
+  if ( fSuppressOn ) {
+    out << myname << "  ADC suppression service:" << endl;
+    m_pzs->print(out, myprefix);
+  } else {
+    out << myname << "  ADC suppression is off.";
+  }
+  out << endl;
+  out << myname << "  Compression service:" << endl;
+  out << endl;
+  m_pcmp->print(out, myprefix);
+  out << myname << "  KeepEmptyChannels:" << fKeepEmptyChannels << endl;
+  mf::LogInfo("SimWireUniqNoiseDUNE::reconfigure") << out.str();
+
+  return;
+}
+
+//**********************************************************************
+
+void SimWireUniqNoiseDUNE::beginJob() { }
+
+//**********************************************************************
+
+void SimWireUniqNoiseDUNE::endJob() { }
+
+//**********************************************************************
+
+void SimWireUniqNoiseDUNE::produce(art::Event& evt) {
+  const string myname = "SimWireUniqNoiseDUNE::produce: ";
+
+  // Make a vector of const sim::SimChannel* that has same number
+  // of entries as the number of channels in the detector
+  // and set the entries for the channels that have signal on them
+  // using the chanHandle
+  std::vector<const sim::SimChannel*> chanHandle;
+  std::vector<const sim::SimChannel*> simChannels(m_pgeo->Nchannels(), nullptr);
+  evt.getView(fSimChannelLabel, chanHandle);
+  for ( size_t c=0; c<chanHandle.size(); ++c ) {
+    simChannels[chanHandle[c]->Channel()] = chanHandle[c];
+  }
+
+  // Do the same as above, but for the RawDigits, so we can map from channel number to digit
+  std::vector<const raw::RawDigit*> inputDigitsHandle;
+  std::vector<const raw::RawDigit*> inputDigits(m_pgeo->Nchannels(), nullptr);
+  if(fUseRawDigitInput){
+    evt.getView(fRawDigitInputLabel, inputDigitsHandle);
+    for ( size_t c=0; c<inputDigitsHandle.size(); ++c ) {
+      const raw::RawDigit* dig=inputDigitsHandle[c];
+      inputDigits[dig->Channel()] = dig;
+    }
+  }
+
+  // make an unique_ptr of sim::SimDigits that allows ownership of the produced
+  // digits to be transferred to the art::Event after the put statement below
+  std::unique_ptr<std::vector<raw::RawDigit>>  digcol(new std::vector<raw::RawDigit>);
+
+  // Fetch the number of ticks to write out for each channel.
+  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
+  auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clockData);
+  unsigned int nTickReadout  = detProp.ReadOutWindowSize();
+  m_pcns->newEvent();
+  // Loop over channels.
+  std::map<int,double>::iterator mapIter;
+  for ( unsigned int chan = 0; chan<m_pgeo->Nchannels(); ++chan ) {
+
+    // Get the SimChannel for this channel
+    const sim::SimChannel* psc = simChannels[chan];
+
+    // Create vector that holds the floating ADC count for each tick.
+    std::vector<AdcSignal> fChargeWork;
+
+    if(fUseRawDigitInput){
+      const raw::RawDigit* dig=inputDigits[chan];
+      fChargeWork.insert(fChargeWork.end(), dig->ADCs().begin(), dig->ADCs().end());
+    }
+    else{
+      // Extract the floating ADC count from the SimChannel for each tick in the channel.
+      m_pscx->extract(clockData, psc, fChargeWork);
+    }
+
+    // Add noise to each tick in the channel.
+    if ( fNoiseOn ) {
+      m_pcns->addNoise(clockData, detProp, chan, fChargeWork);
+    }
+
+    // Option to display signals before adding pedestals.
+    // E.g. logsig = chan==1000.
+    bool logsig = false;
+    if ( logsig ) {
+      cout << myname << "Signals after noise:" << endl;
+      for ( unsigned int itck=0; itck<fChargeWork.size(); ++itck ) {
+        if(fChargeWork[itck] > 0 )
+          cout << myname << " " << itck << ": chg=" << fChargeWork[itck] << endl;
+      }
+    }
+
+    // Add pedestal.
+    float pedval = 0.0; // Pedestal to be recorded in RawDigits collection
+    float pedrms = 0.0; // Pedestal RMS to be recorded in RawDigits collection
+    if ( fPedestalOn ) {
+      m_ppad->addPedestal(chan, fChargeWork, pedval, pedrms);
+    }
+
+    // Convert floating ADC to integral ADC count.
+    std::vector<short> adcvec(fChargeWork.size(), 0);
+    const short adcmax = 4095;
+    for ( unsigned int itck=0; itck<fChargeWork.size(); ++itck ) {
+      AdcSignal adcin = fChargeWork[itck];
+      short adc = 0;
+      bool useOldAdc = false;
+      // New ADC calculation (with tool).
+      if ( m_pads ) {
+        if(adcin > 0)
+          //cout << " adcin " << adcin << endl;
+        adc = m_pads->count(adcin, chan);
+      } else {
+        //cout << myname << "WARNING: AdcSimulator not found." << endl;
+        useOldAdc = true;
+      }
+      // Old ADC calculation.
+      if ( useOldAdc ) {
+        short adc1 = 0;
+        if ( adcin > 0 ) adc1 = (short) (adcin + 0.5);
+        if ( adc1 > adcmax ) adc1 = adcmax;
+        bool show = m_pads && adc1 != adc;
+
+        static int ndump = 1000;
+        if ( ndump && show ) {
+          cout << myname << "  ADC: " << adc1 << " --> " << adc << " (" << adcin << ")" << endl;
+          --ndump;
+        }
+        adc = adc1;
+      }
+      // Record the ADC value.
+      adcvec[itck] = adc;
+    }
+    // Resize to the correct number of time samples, dropping extra samples.
+    adcvec.resize(nTickReadout);
+
+    // Add stuck bits.
+    if ( fDistortOn ) {
+      m_pdis->modify(chan, adcvec);
+    }
+
+    // Zero suppress.
+    AdcCountSelection acs(adcvec, chan, pedval);
+    if ( fSuppressOn ) {
+      m_pzs->filter(acs);
+    }
+    int nkeep = 0;
+    for ( bool kept : acs.filter ) if ( kept ) ++nkeep;
+
+    // If flag is not set and channel is empty, skip it.
+    if ( ! fKeepEmptyChannels && nkeep==0 ) continue;
+
+    // Compress.
+    raw::Compress_t comp = raw::kNone;
+    m_pcmp->compress(adcvec, acs.filter, pedval, comp);
+
+    // Create and store raw digit.
+    raw::RawDigit rd(chan, nTickReadout, adcvec, comp);
+    rd.SetPedestal(pedval, pedrms);
+    digcol->push_back(rd);            // add this digit to the collection
+
+  }  // end loop over channels
+
+  evt.put(std::move(digcol));
+
+}

--- a/dunesim/DetSim/Service/CMakeLists.txt
+++ b/dunesim/DetSim/Service/CMakeLists.txt
@@ -157,6 +157,21 @@ cet_build_plugin(SPhaseChannelNoiseService
                 ROOT_BASIC_LIB_LIST
              )
 
+cet_build_plugin(SPhaseUniqChannelNoiseService   
+                art::service
+                larcorealg::Geometry
+                dunecore::SignalShapingServiceDUNE_service
+                art_root_io::tfile_support
+                ROOT::Core
+                art_root_io::TFileService_service
+                nurandom::RandomUtils_NuRandomService_service
+                art::Framework_Core
+                art::Utilities canvas
+                cetlib::cetlib 
+		cetlib_except::cetlib_except
+                CLHEP
+                ROOT_BASIC_LIB_LIST
+             )
 
 cet_build_plugin(WhiteChannelNoiseService   
                 art::service

--- a/dunesim/DetSim/Service/SPhaseUniqChannelNoiseService.h
+++ b/dunesim/DetSim/Service/SPhaseUniqChannelNoiseService.h
@@ -1,0 +1,174 @@
+// SPhaseUniqChannelNoiseService
+
+// Jingbo Wang (jiowang@ucdavis.edu)
+// March 2019
+//
+// Implementation of a general TPC channel noise model with:
+// (1) white noise
+// (2) Inherent Gaussian noise in frequency
+// (3) MicroBooNE noise in frequency
+// (4) Coherent noise (exponential + Gaussian) in frequency 
+//     (Note a: phase at each frequency bin is randamized at the moment. Will be updated soon
+//      Note b: Currently, consecutive offline channels (configurable) are grouped together and 
+//              the same coherent noise waveform is assigned to channels within the same group. )
+//
+// The default parameters are obtained from the ProtoDUNE-SP data (run 4096)
+// fcl file: dunetpc/fcl/protodune/detsim/protoDUNE_detsim_data_driven_noise.fcl
+//
+
+#ifndef SPhaseUniqChannelNoiseService_H
+#define SPhaseUniqChannelNoiseService_H
+
+#include "dunecore/DuneInterface/Service/UniqChannelNoiseService.h"
+#include <vector>
+#include <iostream>
+
+class TH1;
+class TF1;
+namespace CLHEP {
+class HepRandomEngine;
+}
+
+class SPhaseUniqChannelNoiseService : public UniqChannelNoiseService {
+
+public:
+
+  // Ctor.
+  SPhaseUniqChannelNoiseService(fhicl::ParameterSet const& pset);
+
+  // Ctor.
+  SPhaseUniqChannelNoiseService(fhicl::ParameterSet const& pset, art::ActivityRegistry&);
+
+  // Dtor.
+  ~SPhaseUniqChannelNoiseService();
+
+  // Add noise to a signal array.
+  int addNoise(detinfo::DetectorClocksData const&,
+               detinfo::DetectorPropertiesData const&,
+               Channel chan, AdcSignalVector& sigs) const;
+
+  void newEvent();
+  unsigned int getGroupNumberFromOfflineChannel(unsigned int offlinechan) const;
+  void setNumNoiseArrayPoints(unsigned int n_np, unsigned int n_cnp);
+  void setIdxNoiseArrayPoints(unsigned int i_n, unsigned int i_cn);
+
+  // Print the configuration.
+  std::ostream& print(std::ostream& out =std::cout, std::string prefix ="") const;
+
+private:
+ 
+  // Fill the noise vectors.
+  void generateNoise(detinfo::DetectorClocksData const& clockData);
+  
+  // Fill a noise vector.
+  // Input vector contents are lost.
+  // The size of the vector is obtained from the FFT service.
+  void generateMicroBooNoise(detinfo::DetectorClocksData const& clockData,
+                             float wirelength, float ENOB,
+                     AdcSignalVector& noise, TH1* aNoiseHist) const;
+  void generateGaussianNoise(detinfo::DetectorClocksData const& clockData,
+                             AdcSignalVector& noise, std::vector<float> gausNorm,
+	                    std::vector<float> gausMean, std::vector<float> gausSigma,
+	                    TH1* aNoiseHist) const;
+  void generateCoherentNoise(detinfo::DetectorClocksData const& clockData,
+                             AdcSignalVector& noise, std::vector<float> gausNorm,
+	                    std::vector<float> gausMean, std::vector<float> gausSigma,
+	                    float cohExpNorm, float cohExpWidth, float cohExpOffset, 
+	                    TH1* aNoiseHist) const;
+  
+  // Make coherent groups
+  void makeCoherentGroupsByOfflineChannel(unsigned int nchpergroup);
+  std::vector<unsigned int> fChannelGroupMap;   ///< assign each channel a group number
+  std::vector<int> fGroupCoherentNoiseMap; ///< assign each group a noise 
+  //unsigned int getGroupNumberFromOfflineChannel(unsigned int offlinechan) const;
+  unsigned int getCohNoiseChanFromGroup(unsigned int cohgroup) const;
+  
+  // General parameters
+  bool         fGenUniqNoise;      ///< generate unique noise per channel per event
+  bool         fSpecifyNoisePoint; ///< generate specified number of unique noise points 
+  unsigned int fNoiseArrayPoints;  ///< number of points in randomly generated noise array
+  unsigned int fIdxNoiseArrayPoint;
+  int          fRandomSeed;        ///< Seed for random number service. If absent or zero, use SeedSvc.
+  int          fLogLevel;          ///< Log message level: 0=quiet, 1=init only, 2+=every event
+  
+  // Inherent White noise parameters
+  bool         fEnableWhiteNoise;
+  float        fWhiteNoiseZ;       ///< Level (per freq bin) for white noise for Z.
+  float        fWhiteNoiseU;       ///< Level (per freq bin) for white noise for U.
+  float        fWhiteNoiseV;       ///< Level (per freq bin) for white noise for V.  
+  
+  // Inherent Gaussian noise
+  bool         fEnableGaussianNoise;
+  std::vector<float>	fGausNormU;		///<  noise scale factor for the gaussian component in coherent noise
+  std::vector<float>	fGausMeanU;		///<  mean of the gaussian component in coherent noise
+  std::vector<float>	fGausSigmaU;	///<  sigma of the gaussian component in coherent noise
+  std::vector<float>	fGausNormV;		///<  noise scale factor for the gaussian component in coherent noise
+  std::vector<float>	fGausMeanV;		///<  mean of the gaussian component in coherent noise
+  std::vector<float>	fGausSigmaV;	///<  sigma of the gaussian component in coherent noise
+  std::vector<float>	fGausNormZ;		///<  noise scale factor for the gaussian component in coherent noise
+  std::vector<float>	fGausMeanZ;		///<  mean of the gaussian component in coherent noise
+  std::vector<float>	fGausSigmaZ;	///<  sigma of the gaussian component in coherent noise
+  
+  // Inherent MicroBoone noise parameters
+  bool         fEnableMicroBooNoise;  ///< enable MicroBooNE noise model
+  float        fENOB;                 ///< Effective number of bits
+  float        fWirelengthZ;
+  float        fWirelengthU;
+  float        fWirelengthV;
+  std::vector<float>  fNoiseFunctionParameters;  ///< Parameters in the MicroBooNE noise model
+  TF1* fUBNoisePoisFnc;
+  TF1* fUBNoiseWrLDFnc;
+  TF1* fUBNoiseGainFnc;
+
+  // Coherent Noise parameters
+  bool         fEnableCoherentNoise;
+  unsigned int fNChannelsPerCoherentGroup;
+  unsigned int fNCoherentGroups;
+  unsigned int fExpNoiseArrayPoints;  ///< number of points in randomly generated noise array
+  unsigned int fCohNoiseArrayPoints;  ///< number of points in randomly generated noise array
+  unsigned int fIdxCohNoiseArrayPoint;
+  float        fCohExpNorm;           ///< noise scale factor for the exponential component component in coherent noise
+  float        fCohExpWidth;          ///< width of the exponential component in coherent noise
+  float        fCohExpOffset;         ///< Amplitude offset of the exponential background component in coherent noise
+  std::vector<float>	fCohGausNorm;		///<  noise scale factor for the gaussian component in coherent noise
+  std::vector<float>	fCohGausMean;		///<  mean of the gaussian component in coherent noise
+  std::vector<float>	fCohGausSigma;	///<  sigma of the gaussian component in coherent noise 
+  TF1 *fCohNoiseFnc;
+  TF1* fCohPoisFnc;
+  
+  // Inherent Gausian noise arrays
+  AdcSignalVectorVector fGausNoiseZ;
+  AdcSignalVectorVector fGausNoiseU;
+  AdcSignalVectorVector fGausNoiseV;
+  
+  // Inherent MicroBoo noise arrays
+  AdcSignalVectorVector fMicroBooNoiseZ;  
+  AdcSignalVectorVector fMicroBooNoiseU; 
+  AdcSignalVectorVector fMicroBooNoiseV;
+  
+  // Coherent Noise array.
+  AdcSignalVectorVector fCohNoise;  ///< noise on each channel for each time for all planes
+  
+
+  // Histograms.
+  
+  TH1* fGausNoiseHistZ;     ///< distribution of noise counts for Z
+  TH1* fGausNoiseHistU;     ///< distribution of noise counts for U
+  TH1* fGausNoiseHistV;     ///< distribution of noise counts for V
+  TH1* fGausNoiseChanHist;  ///< distribution of accessed noise samples
+
+  TH1* fMicroBooNoiseHistZ;     ///< distribution of noise counts for Z
+  TH1* fMicroBooNoiseHistU;     ///< distribution of noise counts for U
+  TH1* fMicroBooNoiseHistV;     ///< distribution of noise counts for V
+  TH1* fMicroBooNoiseChanHist;  ///< distribution of accessed noise samples
+  
+  TH1* fCohNoiseHist;      ///< distribution of noise counts
+  TH1* fCohNoiseChanHist;  ///< distribution of accessed noise samples
+
+  CLHEP::HepRandomEngine* m_pran;
+
+};
+
+DECLARE_ART_SERVICE_INTERFACE_IMPL(SPhaseUniqChannelNoiseService, UniqChannelNoiseService, LEGACY)
+
+#endif

--- a/dunesim/DetSim/Service/SPhaseUniqChannelNoiseService_service.cc
+++ b/dunesim/DetSim/Service/SPhaseUniqChannelNoiseService_service.cc
@@ -1,0 +1,663 @@
+// SPhaseUniqChannelNoiseService.cxx
+// Jingbo Wang
+// January 2019
+
+#include "dunesim/DetSim/Service/SPhaseUniqChannelNoiseService.h"
+#include "art/Framework/Services/Registry/ServiceDefinitionMacros.h"
+#include <sstream>
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+#include "lardata/Utilities/LArFFT.h"
+#include "larcore/Geometry/Geometry.h"
+#include "nurandom/RandomUtils/NuRandomService.h"
+#include "art_root_io/TFileService.h"
+#include "CLHEP/Random/JamesRandom.h"
+#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/RandGauss.h"
+#include "TH1F.h"
+#include "TRandom3.h"
+#include "TF1.h"
+#include "TMath.h"
+
+using std::cout;
+using std::ostream;
+using std::endl;
+using std::string;
+using std::ostringstream;
+using rndm::NuRandomService;
+using CLHEP::HepJamesRandom;
+
+//**********************************************************************
+
+SPhaseUniqChannelNoiseService::
+SPhaseUniqChannelNoiseService(fhicl::ParameterSet const& pset)
+: fRandomSeed(0), fLogLevel(1),
+  fGausNoiseHistZ(nullptr), fGausNoiseHistU(nullptr), fGausNoiseHistV(nullptr),
+  fGausNoiseChanHist(nullptr),
+  fMicroBooNoiseHistZ(nullptr), fMicroBooNoiseHistU(nullptr), fMicroBooNoiseHistV(nullptr),
+  fMicroBooNoiseChanHist(nullptr),
+  fCohNoiseHist(nullptr), fCohNoiseChanHist(nullptr),
+  m_pran(nullptr) {
+  const string myname = "SPhaseUniqChannelNoiseService::ctor: ";
+  fSpecifyNoisePoint = pset.get<bool>("SpecifyNoisePoint");
+  fGenUniqNoise      = pset.get<bool>("GenUniqNoise");
+  fNoiseArrayPoints  = pset.get<unsigned int>("NoiseArrayPoints");
+  bool haveSeed      = pset.get_if_present<int>("RandomSeed", fRandomSeed);
+  
+  fEnableWhiteNoise  = pset.get<bool>("EnableWhiteNoise");
+  fWhiteNoiseZ       = pset.get<double>("WhiteNoiseZ");
+  fWhiteNoiseU       = pset.get<double>("WhiteNoiseU");
+  fWhiteNoiseV       = pset.get<double>("WhiteNoiseV");
+  
+  fEnableGaussianNoise = pset.get<bool>("EnableGaussianNoise");
+  fGausNormU     = pset.get<std::vector<float>>("GausNormU");
+  fGausMeanU     = pset.get<std::vector<float>>("GausMeanU");
+  fGausSigmaU    = pset.get<std::vector<float>>("GausSigmaU");
+  fGausNormV     = pset.get<std::vector<float>>("GausNormV");
+  fGausMeanV     = pset.get<std::vector<float>>("GausMeanV");
+  fGausSigmaV    = pset.get<std::vector<float>>("GausSigmaV");
+  fGausNormZ     = pset.get<std::vector<float>>("GausNormZ");
+  fGausMeanZ     = pset.get<std::vector<float>>("GausMeanZ");
+  fGausSigmaZ    = pset.get<std::vector<float>>("GausSigmaZ");
+  
+  fEnableMicroBooNoise = pset.get<bool>("EnableMicroBooNoise");
+  fENOB              = pset.get<double>("EffectiveNBits");
+  fWirelengthZ       = pset.get<double>("WireLengthZ");
+  fWirelengthU       = pset.get<double>("WireLengthU");
+  fWirelengthV       = pset.get<double>("WireLengthV");
+  fNoiseFunctionParameters   = pset.get<std::vector<float>>("NoiseFunctionParameters");
+  if ( fEnableMicroBooNoise ) {
+    fUBNoisePoisFnc = 
+    new TF1("_poisson", "[0]**(x) * exp(-[0]) / ROOT::Math::tgamma(x+1.)", 0, 30);
+    double params[1] = {0.};
+    params[0] = 3.30762;
+    fUBNoisePoisFnc->SetParameters(params);
+
+    fUBNoiseWrLDFnc = new TF1("_wld_f", "[0] + [1]*x", 0.0, 1000);
+    double wldparams[2] = {0.};
+    wldparams[0] = 0.395;
+    wldparams[1] = 0.001304;
+    fUBNoiseWrLDFnc->SetParameters(wldparams);
+
+    //fUBNoiseGainFnc = 
+    //  new TF1("_pfn_f1", "([0]*1/(x/1000*[8]/2) + ([1]*exp(-0.5*(((x/1000*[8]/2)-[2])/[3])**2)*exp(-0.5*pow(x/1000*[8]/(2*[4]),[5])))*[6]) + [7]", 0.0, 0.5*ntick*binWidth);
+  } 
+  fEnableCoherentNoise = pset.get<bool>("EnableCoherentNoise");
+  fCohNoiseArrayPoints  = pset.get<unsigned int>("CohNoiseArrayPoints");
+  fCohExpNorm       = pset.get<float>("CohExpNorm");
+  fCohExpWidth      = pset.get<float>("CohExpWidth");
+  fCohExpOffset    = pset.get<float>("CohExpOffset");
+  fCohGausNorm     = pset.get<std::vector<float>>("CohGausNorm");
+  fCohGausMean     = pset.get<std::vector<float>>("CohGausMean");
+  fCohGausSigma    = pset.get<std::vector<float>>("CohGausSigma");
+  fNChannelsPerCoherentGroup      = pset.get<unsigned int>("NChannelsPerCoherentGroup");
+  if ( fEnableCoherentNoise ) {
+    //--- get number of gaussians ---  
+    int a = fCohGausNorm.size();
+    int b = fCohGausMean.size();
+    int c = fCohGausSigma.size();
+    int NGausians = a<b?a:b;
+    NGausians = NGausians<c?NGausians:c;
+    //--- set function formula ---
+    std::stringstream  name;
+    name.str("");
+    for(int i=0;i<NGausians;i++) {
+  	name<<"["<<3*i<<"]*exp(-0.5*pow((x-["<<3*i+1<<"])/["<<3*i+2<<"],2))+";
+    }
+    name<<"["<<3*NGausians<<"]*exp(-x/["<<3*NGausians+1<<"]) + ["<<3*NGausians+2<<"]";
+    fCohNoiseFnc = new TF1("funcGausCohsNoise",name.str().c_str(), 0, 1200);
+    fCohNoiseFnc ->SetNpx(12000);
+    for(int i=0;i<NGausians;i++) {
+      fCohNoiseFnc ->SetParameter(3*i, fCohGausNorm.at(i));	
+      fCohNoiseFnc ->SetParameter(3*i+1, fCohGausMean.at(i));	
+      fCohNoiseFnc ->SetParameter(3*i+2, fCohGausSigma.at(i));	
+    }
+    fCohNoiseFnc ->SetParameter(3*NGausians, fCohExpNorm);
+    fCohNoiseFnc ->SetParameter(3*NGausians+1, fCohExpWidth);
+    fCohNoiseFnc ->SetParameter(3*NGausians+2, fCohExpOffset);
+
+    // custom poisson  
+    fCohPoisFnc = new TF1("_poisson", "[0]**(x) * exp(-[0]) / ROOT::Math::tgamma(x+1.)", 0, 30);
+    // poisson mean
+    double params[1] = {0.};
+    params[0] = 4; // hard-coded for now. To be updated with data
+    fCohPoisFnc->SetParameters(params);
+  } 
+  
+  if ( fRandomSeed == 0 ) haveSeed = false;
+  pset.get_if_present<int>("LogLevel", fLogLevel);
+  int seed = fRandomSeed;
+  art::ServiceHandle<art::TFileService> tfs;
+  fMicroBooNoiseHistZ = tfs->make<TH1F>("MicroBoo znoise", ";Z Noise [ADC counts];", 1000,   -10., 10.);
+  fMicroBooNoiseHistU = tfs->make<TH1F>("MicroBoo unoise", ";U Noise [ADC counts];", 1000,   -10., 10.);
+  fMicroBooNoiseHistV = tfs->make<TH1F>("MicroBoo vnoise", ";V Noise [ADC counts];", 1000,   -10., 10.);
+  fMicroBooNoiseChanHist = tfs->make<TH1F>("MicroBoo NoiseChan", ";MicroBoo Noise channel;", fNoiseArrayPoints, 0, fNoiseArrayPoints);
+  fGausNoiseHistZ = tfs->make<TH1F>("Gaussian znoise", ";Z Noise [ADC counts];", 1000,   -10., 10.);
+  fGausNoiseHistU = tfs->make<TH1F>("Gaussian unoise", ";U Noise [ADC counts];", 1000,   -10., 10.);
+  fGausNoiseHistV = tfs->make<TH1F>("Gaussian vnoise", ";V Noise [ADC counts];", 1000,   -10., 10.);
+  fGausNoiseChanHist = tfs->make<TH1F>("Gaussian NoiseChan", ";Gaussian Noise channel;", fNoiseArrayPoints, 0, fNoiseArrayPoints);
+  fCohNoiseHist = tfs->make<TH1F>("Cohnoise", ";Coherent Noise [ADC counts];", 1000,   -10., 10.);                           
+  fCohNoiseChanHist = tfs->make<TH1F>("CohNoiseChan", ";CohNoise channel;", fCohNoiseArrayPoints, 0, fCohNoiseArrayPoints);// III = for each instance of this class.
+  string rname = "SPhaseUniqChannelNoiseService";
+  if ( haveSeed ) {
+    if ( fLogLevel > 0 ) cout << myname << "WARNING: Using hardwired seed." << endl;
+    m_pran = new HepJamesRandom(seed);
+  } else {
+    if ( fLogLevel > 0 ) cout << myname << "Using NuRandomService." << endl;
+    art::ServiceHandle<NuRandomService> seedSvc;
+    m_pran = new HepJamesRandom;
+    if ( fLogLevel > 0 ) cout << myname << "    Initial seed: " << m_pran->getSeed() << endl;
+    seedSvc->registerEngine(NuRandomService::CLHEPengineSeeder(m_pran), rname);
+  }
+  if ( fLogLevel > 0 ) cout << myname << "  Registered seed: " << m_pran->getSeed() << endl;
+  if ( !fGenUniqNoise && !fSpecifyNoisePoint ) {
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
+    generateNoise(clockData);
+  } else {
+    makeCoherentGroupsByOfflineChannel(fNChannelsPerCoherentGroup);
+    if ( !fSpecifyNoisePoint ) {
+      art::ServiceHandle<geo::Geometry> geo;
+      fNoiseArrayPoints = geo->Nchannels();
+      fCohNoiseArrayPoints = fNCoherentGroups;
+    }
+  }
+  if ( fLogLevel > 1 ) print() << endl;
+}
+
+//**********************************************************************
+
+SPhaseUniqChannelNoiseService::
+SPhaseUniqChannelNoiseService(fhicl::ParameterSet const& pset, art::ActivityRegistry&)
+: SPhaseUniqChannelNoiseService(pset) { }
+
+//**********************************************************************
+
+SPhaseUniqChannelNoiseService::~SPhaseUniqChannelNoiseService() {
+  const string myname = "SPhaseUniqChannelNoiseService::dtor: ";
+  if ( fLogLevel > 0 ) {
+    cout << myname << "Deleting random engine with seed " << m_pran->getSeed() << endl;
+  }
+  delete m_pran;
+}
+
+//**********************************************************************
+
+int SPhaseUniqChannelNoiseService::addNoise(detinfo::DetectorClocksData const&,
+                                        detinfo::DetectorPropertiesData const&,
+                                        Channel chan, AdcSignalVector& sigs) const {
+  CLHEP::RandFlat flat(*m_pran);
+  CLHEP::RandGauss gaus(*m_pran);
+  	
+  unsigned int microbooNoiseChan = -999;
+  if ( fEnableMicroBooNoise ) {
+    if ( fSpecifyNoisePoint ) {
+      microbooNoiseChan = fIdxNoiseArrayPoint;
+    } else if ( fGenUniqNoise ) {
+      microbooNoiseChan = chan;
+    } else {
+      microbooNoiseChan = flat.fire()*fNoiseArrayPoints;
+      if ( microbooNoiseChan == fNoiseArrayPoints ) --microbooNoiseChan;
+      fMicroBooNoiseChanHist->Fill(microbooNoiseChan);
+    }
+  }
+  unsigned int gausNoiseChan = -999;
+  if (fEnableGaussianNoise) {
+    if ( fSpecifyNoisePoint ) {
+      gausNoiseChan = fIdxNoiseArrayPoint;
+    } else if ( fGenUniqNoise ) {
+      gausNoiseChan = chan;
+    } else {
+      gausNoiseChan = flat.fire()*fNoiseArrayPoints;
+      if ( gausNoiseChan == fNoiseArrayPoints ) --gausNoiseChan;
+      fGausNoiseChanHist->Fill(gausNoiseChan);
+    }
+  }
+  unsigned int cohNoisechan = -999;
+  unsigned int groupNum = -999;
+  if ( fEnableCoherentNoise ) {
+    groupNum = getGroupNumberFromOfflineChannel(chan);
+    if ( fSpecifyNoisePoint ) {
+      cohNoisechan = fIdxCohNoiseArrayPoint;
+    } else if ( fGenUniqNoise ) {
+      cohNoisechan = groupNum;
+    } else {
+      cohNoisechan = getCohNoiseChanFromGroup(groupNum);
+      if ( cohNoisechan == fCohNoiseArrayPoints ) cohNoisechan = fCohNoiseArrayPoints-1;
+      fCohNoiseChanHist->Fill(cohNoisechan);
+    }
+  }
+  
+  art::ServiceHandle<geo::Geometry> geo;
+  const geo::View_t view = geo->View(chan);
+  for ( unsigned int itck=0; itck<sigs.size(); ++itck ) {
+    double tnoise = 0;
+    if ( view==geo::kU ) {
+      if(fEnableWhiteNoise)    tnoise += fWhiteNoiseU*gaus.fire();
+      if(fEnableMicroBooNoise) tnoise += fMicroBooNoiseU[microbooNoiseChan][itck];
+      if(fEnableGaussianNoise) tnoise += fGausNoiseU[gausNoiseChan][itck];
+      if(fEnableCoherentNoise) tnoise += fCohNoise[cohNoisechan][itck];
+    } 
+    else if ( view==geo::kV ) {
+    	if(fEnableWhiteNoise)    tnoise = fWhiteNoiseV*gaus.fire();
+      if(fEnableMicroBooNoise) tnoise += fMicroBooNoiseV[microbooNoiseChan][itck];
+      if(fEnableGaussianNoise) tnoise += fGausNoiseV[gausNoiseChan][itck];
+      if(fEnableCoherentNoise) tnoise += fCohNoise[cohNoisechan][itck];
+    } 
+    else {
+    	if(fEnableWhiteNoise)    tnoise += fWhiteNoiseZ*gaus.fire();
+    	if(fEnableMicroBooNoise) tnoise += fMicroBooNoiseZ[microbooNoiseChan][itck];
+      if(fEnableGaussianNoise) tnoise += fGausNoiseZ[gausNoiseChan][itck];
+      if(fEnableCoherentNoise) tnoise += fCohNoise[cohNoisechan][itck];
+    }      
+    sigs[itck] += tnoise;
+  }
+  return 0;
+}
+
+//**********************************************************************
+
+ostream& SPhaseUniqChannelNoiseService::print(ostream& out, string prefix) const {
+  out << prefix << "SPhaseUniqChannelNoiseService: " << endl;
+  
+  out << prefix << " SpecifyNoisePoint: " << fSpecifyNoisePoint << endl;  
+  out << prefix << "      GenUniqNoise: " << fGenUniqNoise << endl;  
+  out << prefix << "          LogLevel: " <<  fLogLevel << endl;
+  out << prefix << "        RandomSeed: " <<  fRandomSeed << endl;
+  out << prefix << "  NoiseArrayPoints: " << fNoiseArrayPoints << endl;
+  
+  out << prefix << "  EnableWhiteNoise: " << fEnableWhiteNoise   << endl;  
+  out << prefix << "       WhiteNoiseZ: " << fWhiteNoiseZ << endl;
+  out << prefix << "       WhiteNoiseU: " << fWhiteNoiseU << endl;
+  out << prefix << "       WhiteNoiseV: " << fWhiteNoiseV << endl; 
+  
+  out << prefix << "EnableGaussianNoise: " << fEnableGaussianNoise  << endl;
+  out << prefix << "     GausNormU: [ ";  
+  for(int i=0; i<(int)fGausNormU.size(); i++) { out <<  fGausNormU.at(i) << " ";}
+  out << " ]" << endl;
+  out << prefix << "     GausMeanU: [ ";  
+  for(int i=0; i<(int)fGausMeanU.size(); i++) { out <<  fGausMeanU.at(i) << " ";}
+  out << " ]" << endl;
+  out << prefix << "     GausSigmaU: [ ";  
+  for(int i=0; i<(int)fGausSigmaU.size(); i++) { out <<  fGausSigmaU.at(i) << " ";}
+  out << " ]" << endl;
+  out << prefix << "     GausNormV: [ ";  
+  for(int i=0; i<(int)fGausNormV.size(); i++) { out <<  fGausNormV.at(i) << " ";}
+  out << " ]" << endl;
+  out << prefix << "     GausMeanV: [ ";  
+  for(int i=0; i<(int)fGausMeanV.size(); i++) { out <<  fGausMeanV.at(i) << " ";}
+  out << " ]" << endl;
+  out << prefix << "     GausSigmaV: [ ";  
+  for(int i=0; i<(int)fGausSigmaV.size(); i++) { out <<  fGausSigmaV.at(i) << " ";}
+  out << " ]" << endl;
+  out << prefix << "     GausNormZ: [ ";  
+  for(int i=0; i<(int)fGausNormZ.size(); i++) { out <<  fGausNormZ.at(i) << " ";}
+  out << " ]" << endl;
+  out << prefix << "     GausMeanZ: [ ";  
+  for(int i=0; i<(int)fGausMeanZ.size(); i++) { out <<  fGausMeanZ.at(i) << " ";}
+  out << " ]" << endl;
+  out << prefix << "     GausSigmaZ: [ ";  
+  for(int i=0; i<(int)fGausSigmaZ.size(); i++) { out <<  fGausSigmaZ.at(i) << " ";}
+  out << " ]" << endl;
+  
+  out << prefix << "EnableMicroBooNoise: " << fEnableMicroBooNoise  << endl;
+  out << prefix << "    EffectiveNBits: " << fENOB  << endl;
+  out << prefix << "       WireLengthU: " << fWirelengthU  << endl;
+  out << prefix << "       WireLengthV: " << fWirelengthV  << endl;
+  out << prefix << "       WireLengthZ: " << fWirelengthZ  << endl;
+  
+  out << prefix << "EnableCoherentNoise: " << fEnableCoherentNoise   << endl;
+  out << prefix << "ExpNoiseArrayPoints: " << fExpNoiseArrayPoints << endl;
+  out << prefix << "CohNoiseArrayPoints: " << fCohNoiseArrayPoints << endl;
+  out << prefix << "MicroBoo model parameters: [ ";  
+  for(int i=0; i<(int)fNoiseFunctionParameters.size(); i++) { out <<  fNoiseFunctionParameters.at(i) << " ";}
+  out << " ]" << endl;
+  
+  out << prefix << "     CohGausNorm: [ ";  
+  for(int i=0; i<(int)fCohGausNorm.size(); i++) { out <<  fCohGausNorm.at(i) << " ";}
+  out << " ]" << endl;
+  out << prefix << "     CohGausMean: [ ";  
+  for(int i=0; i<(int)fCohGausMean.size(); i++) { out <<  fCohGausMean.at(i) << " ";}
+  out << " ]" << endl;
+  out << prefix << "     CohGausSigma: [ ";  
+  for(int i=0; i<(int)fCohGausSigma.size(); i++) { out <<  fCohGausSigma.at(i) << " ";}
+  out << " ]" << endl;
+  
+  out << prefix << "  Actual random seed: " << m_pran->getSeed();
+  return out;
+}
+
+//**********************************************************************
+
+void SPhaseUniqChannelNoiseService::
+generateMicroBooNoise(detinfo::DetectorClocksData const& clockData,
+                      float wirelength, float ENOB,
+              AdcSignalVector& noise, TH1* aNoiseHist) const {
+  const string myname = "SPhaseUniqChannelNoiseService::generateMicroBooNoise: ";
+  if ( fLogLevel > 1 ) {
+    cout << myname << "Generating noise." << endl;
+    if ( fLogLevel > 2 ) {
+      cout << myname << "    Seed: " << m_pran->getSeed() << endl;
+    }
+  }
+  // Fetch sampling rate.
+  float sampleRate = sampling_rate(clockData);
+  // Fetch FFT service and # ticks.
+  art::ServiceHandle<util::LArFFT> pfft;
+  unsigned int ntick = pfft->FFTSize();
+  // width of frequencyBin in kHz
+  double binWidth = 1.0/(ntick*sampleRate*1.0e-6);
+  CLHEP::RandFlat flat(*m_pran);
+  // Create noise spectrum in frequency.
+  unsigned nbin = ntick/2 + 1;
+  std::vector<TComplex> noiseFrequency(nbin, 0.);
+  double pval = 0.;
+  double phase = 0.;
+  double rnd[3] = {0.};
+  
+  ////////////////////////////// MicroBooNE noise model/////////////////////////////////
+  // vars
+  double fitpar[9] = {0.};
+  
+  // calculate FFT magnitude of noise from ENOB
+  //double baseline_noise = std::sqrt(ntick*1.0/12)*std::pow(2, 12 - fENOB);
+  double wldValue = fUBNoiseWrLDFnc->Eval(wirelength);
+  fitpar[0] = fNoiseFunctionParameters.at(0);
+  fitpar[1] = fNoiseFunctionParameters.at(1);
+  fitpar[2] = fNoiseFunctionParameters.at(2);
+  fitpar[3] = fNoiseFunctionParameters.at(3);
+  fitpar[4] = fNoiseFunctionParameters.at(4);
+  fitpar[5] = fNoiseFunctionParameters.at(5);
+  fitpar[6] = wldValue;
+  fitpar[7] = fNoiseFunctionParameters.at(7);
+  fitpar[8] = ntick;
+  fUBNoiseGainFnc->SetParameters(fitpar);
+  fUBNoiseGainFnc->SetNpx(1000);
+  	
+  for ( unsigned int i=0; i<ntick/2+1; ++i ) {
+    //MicroBooNE noise model
+    double pfnf1val = fUBNoiseGainFnc->Eval((i+0.5)*binWidth);
+    // define FFT parameters
+    //double randomizer = fUBNoisePoisFnc->GetRandom()/params[0];
+    double randomizer = fUBNoisePoisFnc->GetRandom()/3.30762;
+    pval = pfnf1val * randomizer;
+    // random phase angle
+    flat.fireArray(2, rnd, 0, 1);
+    phase = rnd[1]*2.*TMath::Pi();
+    TComplex tc(pval*cos(phase),pval*sin(phase));
+    noiseFrequency[i] += tc;
+  }
+  // Obtain time spectrum from frequency spectrum.
+  noise.clear();
+  noise.resize(ntick,0.0);
+  std::vector<double> tmpnoise(noise.size());
+  pfft->DoInvFFT(noiseFrequency, tmpnoise);
+  noiseFrequency.clear();
+  for ( unsigned int itck=0; itck<noise.size(); ++itck ) {
+    noise[itck] = sqrt(ntick)*tmpnoise[itck];
+  }
+  for ( unsigned int itck=0; itck<noise.size(); ++itck ) {
+    aNoiseHist->Fill(noise[itck]);
+  }
+}
+
+//**********************************************************************
+
+void SPhaseUniqChannelNoiseService::
+generateGaussianNoise(detinfo::DetectorClocksData const& clockData,
+                      AdcSignalVector& noise, std::vector<float> gausNorm,
+	                    std::vector<float> gausMean, std::vector<float> gausSigma,
+	                    TH1* aNoiseHist) const {
+  const string myname = "SPhaseUniqChannelNoiseService::generateGaussianNoise: ";
+  if ( fLogLevel > 1 ) {
+    cout << myname << "Generating Gaussian noise." << endl;  
+  }
+  //--- get number of gaussians ---  
+  int a = gausNorm.size();
+  int b = gausMean.size();
+  int c = gausSigma.size();
+  int NGausians = a<b?a:b;
+  NGausians = NGausians<c?NGausians:c;
+  //--- set function formula ---
+  std::stringstream  name;
+  name.str("");
+  for(int i=0;i<NGausians;i++) {
+  	name<<"["<<3*i<<"]*exp(-0.5*pow((x-["<<3*i+1<<"])/["<<3*i+2<<"],2))+";
+  }
+  name<<"0";
+  TF1 *funcGausNoise = new TF1("funcGausInhNoise",name.str().c_str(), 0, 1200);
+  funcGausNoise->SetNpx(12000);
+  for(int i=0;i<NGausians;i++) {
+    funcGausNoise->SetParameter(3*i, gausNorm.at(i));	
+    funcGausNoise->SetParameter(3*i+1, gausMean.at(i));	
+    funcGausNoise->SetParameter(3*i+2, gausSigma.at(i));	
+  }
+  
+  // Fetch sampling rate.
+  float sampleRate = sampling_rate(clockData);
+  // Fetch FFT service and # ticks.
+  art::ServiceHandle<util::LArFFT> pfft;
+  unsigned int ntick = pfft->FFTSize();
+  CLHEP::RandFlat flat(*m_pran);
+  // Create noise spectrum in frequency.
+  unsigned nbin = ntick/2 + 1;
+  std::vector<TComplex> noiseFrequency(nbin, 0.);
+  double pval = 0.;
+  double phase = 0.;
+  double rnd[2] = {0.};
+  // width of frequencyBin in kHz
+  double binWidth = 1.0/(ntick*sampleRate*1.0e-6);
+  for ( unsigned int i=0; i<ntick/2+1; ++i ) {
+    // coherent noise spectrum 
+    pval = funcGausNoise->Eval((double)i*binWidth);
+    // randomize amplitude within 10%
+    flat.fireArray(2, rnd, 0, 1);
+    pval *= 0.9 + 0.2*rnd[0];
+    // randomize phase angle
+    phase = rnd[1]*2.*TMath::Pi();
+    TComplex tc(pval*cos(phase),pval*sin(phase));
+    noiseFrequency[i] += tc;
+  }
+  // Obtain time spectrum from frequency spectrum.
+  noise.clear();
+  noise.resize(ntick,0.0);
+  std::vector<double> tmpnoise(noise.size());
+  pfft->DoInvFFT(noiseFrequency, tmpnoise);
+  noiseFrequency.clear();
+  
+  for ( unsigned int itck=0; itck<noise.size(); ++itck ) {
+    noise[itck] = sqrt(ntick)*tmpnoise[itck];
+  }
+  for ( unsigned int itck=0; itck<noise.size(); ++itck ) {
+    aNoiseHist->Fill(noise[itck]);
+  }
+  
+  //free memory
+  delete funcGausNoise; funcGausNoise = 0;
+}
+////**********************************************************************
+
+void SPhaseUniqChannelNoiseService::
+generateCoherentNoise(detinfo::DetectorClocksData const& clockData,
+                      AdcSignalVector& noise, std::vector<float> gausNorm,
+	                    std::vector<float> gausMean, std::vector<float> gausSigma,
+	                    float cohExpNorm, float cohExpWidth, float cohExpOffset, 
+	                    TH1* aNoiseHist) const {
+  const string myname = "SPhaseUniqChannelNoiseService::generateCoherentGaussianNoise: ";
+  if ( fLogLevel > 1 ) {
+    cout << myname << "Generating Coherent Gaussian noise." << endl;  
+  }
+  
+  // Fetch sampling rate.
+  float sampleRate = sampling_rate(clockData);
+  // Fetch FFT service and # ticks.
+  art::ServiceHandle<util::LArFFT> pfft;
+  unsigned int ntick = pfft->FFTSize();
+  CLHEP::RandFlat flat(*m_pran);
+  // Create noise spectrum in frequency.
+  unsigned nbin = ntick/2 + 1;
+  std::vector<TComplex> noiseFrequency(nbin, 0.);
+  double pval = 0.;
+  double phase = 0.;
+  double rnd[2] = {0.};
+  // width of frequencyBin in kHz
+  double binWidth = 1.0/(ntick*sampleRate*1.0e-6);
+  for ( unsigned int i=0; i<ntick/2+1; ++i ) {
+    // coherent noise spectrum 
+    pval = fCohNoiseFnc->Eval((double)i*binWidth);
+    // randomize amplitude within 10%
+    flat.fireArray(2, rnd, 0, 1);
+    pval *= 0.9 + 0.2*rnd[0];
+    // randomize amplitude with Poisson randomizers
+    // double randomizer = _poisson->GetRandom()/params[0];
+    // pval *= randomizer;
+    // phase information is not used in this model, but will be added soon.  
+    // randomize phase angle assuming phases of different frequencies are uncorrelated
+    phase = rnd[1]*2.*TMath::Pi(); 
+    TComplex tc(pval*cos(phase),pval*sin(phase));
+    noiseFrequency[i] += tc;
+  }
+  // Obtain time spectrum from frequency spectrum.
+  noise.clear();
+  noise.resize(ntick,0.0);
+  std::vector<double> tmpnoise(noise.size());
+  pfft->DoInvFFT(noiseFrequency, tmpnoise);
+  noiseFrequency.clear();
+  
+  // Note: Assume that the frequency function is obtained from a fit 
+  // of the foward FFT spectrum. In LArSoft, the forward
+  // FFT (doFFT) does not scale the frequency spectrum, but the backward FFT (DoInvFFT) 
+  // does scale the waveform with 1/Nticks. If the frequency function is a fit to the 
+  // LArSoft FFT spectrum, no scaling factor is needed after a backward FFT. 
+  // However, the noise model described here is a fit to the scaled FFT spectrum 
+  // (scaled with 1./sqrt(Nticks)).
+  // Therefore, after InvFFT, the waveform must be nomalized with sqrt(Nticks).
+  
+  for ( unsigned int itck=0; itck<noise.size(); ++itck ) {
+    noise[itck] = sqrt(ntick)*tmpnoise[itck];
+  }
+  for ( unsigned int itck=0; itck<noise.size(); ++itck ) {
+    aNoiseHist->Fill(noise[itck]);
+  }
+  
+  //free memory
+  //delete fCohNoiseFnc; funcCohNoise = 0;
+}
+
+//**********************************************************************
+
+void SPhaseUniqChannelNoiseService::makeCoherentGroupsByOfflineChannel(unsigned int nchpergroup) {
+	CLHEP::RandFlat flat(*m_pran);
+  CLHEP::RandGauss gaus(*m_pran);
+	art::ServiceHandle<geo::Geometry> geo;
+	const unsigned int nchan = geo->Nchannels();
+	fChannelGroupMap.resize(nchan);
+	fNCoherentGroups = 0;
+	if(nchan%nchpergroup == 0) fNCoherentGroups = nchan/nchpergroup;
+	else fNCoherentGroups = nchan/nchpergroup +1;
+	unsigned int cohGroupNo = 0;
+	for(unsigned int chan=0; chan<nchan; chan++) {
+	  cohGroupNo = chan/nchpergroup; //group number
+	  fChannelGroupMap[chan] = cohGroupNo; 
+	}
+	fGroupCoherentNoiseMap.resize(fNCoherentGroups);
+	for(unsigned int ng=0; ng<fNCoherentGroups; ng++) {
+	  unsigned int cohNoiseChan = flat.fire()*fCohNoiseArrayPoints;
+	  fGroupCoherentNoiseMap[ng] = cohNoiseChan;
+	}
+}
+
+//**********************************************************************
+void SPhaseUniqChannelNoiseService::setNumNoiseArrayPoints(unsigned int n_np, unsigned int n_cnp) {
+  fNoiseArrayPoints = n_np;
+  fCohNoiseArrayPoints = n_cnp;
+}
+
+//**********************************************************************
+void SPhaseUniqChannelNoiseService::setIdxNoiseArrayPoints(unsigned int i_n, unsigned int i_cn) {
+  fIdxNoiseArrayPoint = i_n;
+  fIdxCohNoiseArrayPoint = i_cn;
+}
+
+//**********************************************************************
+unsigned int SPhaseUniqChannelNoiseService::getGroupNumberFromOfflineChannel(unsigned int offlinechan) const {
+  return fChannelGroupMap[offlinechan];
+}
+
+//**********************************************************************
+unsigned int SPhaseUniqChannelNoiseService::getCohNoiseChanFromGroup(unsigned int cohgroup) const {
+  return fGroupCoherentNoiseMap[cohgroup];
+}
+
+//**********************************************************************
+
+void SPhaseUniqChannelNoiseService::generateNoise(detinfo::DetectorClocksData const& clockData) {
+  
+  if(fEnableMicroBooNoise) {
+    fMicroBooNoiseZ.clear();
+    fMicroBooNoiseU.clear();
+    fMicroBooNoiseV.clear();
+    fMicroBooNoiseZ.resize(fNoiseArrayPoints);
+    fMicroBooNoiseU.resize(fNoiseArrayPoints);
+    fMicroBooNoiseV.resize(fNoiseArrayPoints);
+    //for ( unsigned int i=0; i<fNoiseArrayPoints; ++i ) {
+    //  if(fMicroBooNoiseZ.size())std::vector<AdcSignal>().swap(fMicroBooNoiseZ[i]);
+    //  if(fMicroBooNoiseU.size())std::vector<AdcSignal>().swap(fMicroBooNoiseU[i]);
+    //  if(fMicroBooNoiseV.size())std::vector<AdcSignal>().swap(fMicroBooNoiseV[i]);
+    //}
+    for ( unsigned int i=0; i<fNoiseArrayPoints; ++i ) {
+      generateMicroBooNoise(clockData, fWirelengthZ, fENOB, fMicroBooNoiseZ[i], fMicroBooNoiseHistZ);
+      generateMicroBooNoise(clockData, fWirelengthU, fENOB, fMicroBooNoiseU[i], fMicroBooNoiseHistU);
+      generateMicroBooNoise(clockData, fWirelengthV, fENOB, fMicroBooNoiseV[i], fMicroBooNoiseHistV);
+    } 
+  }
+  
+  if(fEnableGaussianNoise) {
+    fGausNoiseU.clear();
+    fGausNoiseV.clear();
+    fGausNoiseZ.clear();
+    fGausNoiseU.resize(fNoiseArrayPoints);
+    fGausNoiseV.resize(fNoiseArrayPoints);
+    fGausNoiseZ.resize(fNoiseArrayPoints);
+    for ( unsigned int i=0; i<fNoiseArrayPoints; ++i ) {
+      generateGaussianNoise(clockData, fGausNoiseU[i], fGausNormU, fGausMeanU, fGausSigmaU, fGausNoiseHistU);
+      generateGaussianNoise(clockData, fGausNoiseV[i], fGausNormV, fGausMeanV, fGausSigmaV, fGausNoiseHistV);
+      generateGaussianNoise(clockData, fGausNoiseZ[i], fGausNormZ, fGausMeanZ, fGausSigmaZ, fGausNoiseHistZ);
+    }
+  }
+  
+  if(fEnableCoherentNoise) {
+    if(!fGenUniqNoise && !fSpecifyNoisePoint) {
+      makeCoherentGroupsByOfflineChannel(fNChannelsPerCoherentGroup);
+    }
+    fCohNoise.clear();
+    fCohNoise.resize(fCohNoiseArrayPoints);
+    for ( unsigned int i=0; i<fCohNoiseArrayPoints; ++i ) {
+      generateCoherentNoise(clockData,
+                            fCohNoise[i], fCohGausNorm, fCohGausMean, fCohGausSigma,
+                            fCohExpNorm, fCohExpWidth, fCohExpOffset, 
+                            fCohNoiseHist);
+    }
+  }
+}
+
+//**********************************************************************
+
+void SPhaseUniqChannelNoiseService::newEvent() {
+  if ( fGenUniqNoise || fSpecifyNoisePoint ) {
+    std::cout << " !!!! SPhaseUniqChannelNoiseService: Initializing unique noise arrays for the new event ...." << endl;
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
+
+    float sampleRate = sampling_rate(clockData);
+    // width of frequencyBin in kHz
+    double binWidthXntick = 1.0/(sampleRate*1.0e-6);
+    fUBNoiseGainFnc = 
+      new TF1("_pfn_f1", "([0]*1/(x/1000*[8]/2) + ([1]*exp(-0.5*(((x/1000*[8]/2)-[2])/[3])**2)*exp(-0.5*pow(x/1000*[8]/(2*[4]),[5])))*[6]) + [7]", 0.0, 0.5*binWidthXntick);
+
+    generateNoise(clockData);
+  }
+}
+
+//**********************************************************************
+
+DEFINE_ART_SERVICE_INTERFACE_IMPL(SPhaseUniqChannelNoiseService, UniqChannelNoiseService)
+
+//**********************************************************************

--- a/dunesim/EventGenerator/NuE/NuEScatterGen.fcl
+++ b/dunesim/EventGenerator/NuE/NuEScatterGen.fcl
@@ -21,6 +21,14 @@ standard_nuescattergen_solar:
    IsSupernova:  "false"
    NNu:          "1"
 
+   UseFixedDirection: false # use fixed SN direction specified by {XDir,YDir,ZDir}
+   XDir:              0     # X component of SN direction
+   YDir:              0     # Y component of SN direction
+   ZDir:              1     # Z component of SN direction
+   CustomNuFlavBR:    false # use custom BRs specified by NuFlavBR for each flavor
+   NuFlavBR:          [ 1., 0., 0., 0., 0., 0. ]
+   FlatESpectrum:     false # generate flat energy spectrum for neutrino
+
    EventRateFileName: "/pnfs/dune/resilient/users/dpershey/solar_nue_rates.root"
 }
 
@@ -44,6 +52,14 @@ standard_nuescattergen_supernova:
 
    IsSupernova:  "true"
    NNu:          "250"
+
+   UseFixedDirection: false # use fixed SN direction specified by {XDir,YDir,ZDir}
+   XDir:              0     # X component of SN direction
+   YDir:              0     # Y component of SN direction
+   ZDir:              1     # Z component of SN direction
+   CustomNuFlavBR:    false # use custom BRs specified by NuFlavBR for each flavor
+   NuFlavBR:          [ 1., 0., 0., 0., 0., 0. ]
+   FlatESpectrum:     false # generate flat energy spectrum for neutrino
 
    EventRateFileName: "/pnfs/dune/resilient/users/dpershey/supernova_nue_rates.root"
 }

--- a/dunesim/EventGenerator/NuE/NuEScatterGen_module.cc
+++ b/dunesim/EventGenerator/NuE/NuEScatterGen_module.cc
@@ -1,3 +1,4 @@
+#include <TVector3.h>
 #include <string>
 #include <iostream>
 #include <sstream>
@@ -62,6 +63,11 @@ private:
   bool fIsSupernova;
   int fNNu; // number of neutrinos to generate per supernova
 
+  bool fUseFixedDirection;
+  double fXDir;
+  double fYDir;
+  double fZDir;
+
   // Event rate distributions in energy for each flavor
   TF1 *fNueE;
   TF1 *fNumuE;
@@ -72,6 +78,12 @@ private:
 
   // The neutrino direction, which may be the same for multiple neutrinos
   TVector3 fNuDir;
+
+  // For setting custom BRs and option for setting a flatESpectrum
+  bool fFlatESpectrum;
+  bool fCustomNuFlavBR;
+  std::vector<double> fNuFlavBR;
+  std::vector<double> fSubtotBR;
 
   // Handels the cross section calculation, as a function of outgoing e mom.
   // Depends on ga, gv, the electron mass, and neutrino energy
@@ -92,6 +104,8 @@ evgen::NuEScatterGen::NuEScatterGen(fhicl::ParameterSet const & p) : EDProducer{
   // [0] = gv   [1] = ga   [2] = Enu   [3] = eMass
   // ga and gv depend on neutrino flavor
   fdsigdT = new TF1("xsecform","TMath::Power([0] + [1],2) + TMath::Power([0] - [1],2) * TMath::Power(1-x/[2],2) - ([1]*[1] - [0]*[0] * TMath::Power([3]/[2],2))*x");
+  fRand = new TRandom3(0);
+  gRandom->SetSeed(0);
 }
 
 //------------------------------------------------------------------------------
@@ -102,17 +116,41 @@ evgen::NuEScatterGen::~NuEScatterGen()
 //------------------------------------------------------------------------------
 void evgen::NuEScatterGen::beginJob()
 {
-  TFile* eventrates = TFile::Open(fEventRateFileName.c_str());
-  eventrates->cd();
-
-  fNueE   = (TF1*)eventrates->Get("NueE");
-  fNumuE  = (TF1*)eventrates->Get("NumuE");
-  fNutauE = (TF1*)eventrates->Get("NutauE");
-  fNuebarE   = (TF1*)eventrates->Get("NuebarE");
-  fNumubarE  = (TF1*)eventrates->Get("NumubarE");
-  fNutaubarE = (TF1*)eventrates->Get("NutaubarE");
-
-  fRand = new TRandom3(0);
+  double totNueE, totNumuE, totNutauE, totNuebarE, totNumubarE, totNutaubarE;
+  if (!fFlatESpectrum || !fCustomNuFlavBR) {
+    TFile* eventrates = TFile::Open(fEventRateFileName.c_str());
+    eventrates->cd();
+    fNueE      = (TF1*)eventrates->Get("NueE");
+    fNumuE     = (TF1*)eventrates->Get("NumuE");
+    fNutauE    = (TF1*)eventrates->Get("NutauE");
+    fNuebarE   = (TF1*)eventrates->Get("NuebarE");
+    fNumubarE  = (TF1*)eventrates->Get("NumubarE");
+    fNutaubarE = (TF1*)eventrates->Get("NutaubarE");
+  }
+  if (fCustomNuFlavBR) {
+    totNueE      = fNuFlavBR.at(0);
+    totNumuE     = fNuFlavBR.at(1); 
+    totNutauE    = fNuFlavBR.at(2);
+    totNuebarE   = fNuFlavBR.at(3);
+    totNumubarE  = fNuFlavBR.at(4);
+    totNutaubarE = fNuFlavBR.at(5);
+  } else {
+    totNueE      = fNueE  ->Integral(fMinEnu,fMaxEnu,1e-2);
+    totNumuE     = fNumuE ->Integral(fMinEnu,fMaxEnu,1e-2);
+    totNutauE    = fNutauE->Integral(fMinEnu,fMaxEnu,1e-2);
+    totNuebarE   = fNuebarE  ->Integral(fMinEnu,fMaxEnu,1e-2);
+    totNumubarE  = fNumubarE ->Integral(fMinEnu,fMaxEnu,1e-2);
+    totNutaubarE = fNutaubarE->Integral(fMinEnu,fMaxEnu,1e-2);
+  }
+  double tot = totNueE + totNumuE + totNutauE +
+               totNuebarE + totNumubarE + totNutaubarE;
+  fSubtotBR.push_back( totNueE/tot);
+  fSubtotBR.push_back((totNueE + totNumuE)/tot);
+  fSubtotBR.push_back((totNueE + totNumuE + totNutauE)/tot);
+  fSubtotBR.push_back((totNueE + totNumuE + totNutauE + totNuebarE)/tot);
+  fSubtotBR.push_back((totNueE + totNumuE + totNutauE + totNuebarE +
+                       totNumubarE)/tot);
+  fSubtotBR.push_back(1.);
 }
 
 //------------------------------------------------------------------------------
@@ -142,6 +180,8 @@ void evgen::NuEScatterGen::produce(art::Event & e)
   truth.Add(parts[0]);
   truth.Add(parts[1]);
 
+  // SetNeutrino has incorrect behavior for NuEScatter as it sets the wrong lepton
+  truth.SetNeutrino(simb::kCC, simb::kElectronScattering, simb::kCCQE, 0, 0, 0, -1.0, -1.0, -1.0, -1.0);
   truthcol->push_back(truth);
 
   e.put(std::move(truthcol));
@@ -169,7 +209,24 @@ void evgen::NuEScatterGen::reconfigure(fhicl::ParameterSet const & p)
   fIsSupernova = p.get<bool>("IsSupernova");
   fNNu = p.get<int>("NNu");
 
-  fEventRateFileName = p.get<std::string>("EventRateFileName");
+  fUseFixedDirection = p.get<bool>("UseFixedDirection");
+  if (fUseFixedDirection) {
+    fXDir = p.get<double>("XDir");
+    fYDir = p.get<double>("YDir");
+    fZDir = p.get<double>("ZDir");
+  }
+
+  fCustomNuFlavBR = p.get<bool>("CustomNuFlavBR");
+  if (!fFlatESpectrum || !fCustomNuFlavBR) {
+    fEventRateFileName = p.get<std::string>("EventRateFileName");
+  }
+  if (fCustomNuFlavBR) {
+    fNuFlavBR = p.get<std::vector<double>>("NuFlavBR");
+    std::cout << "NuEScatterGen_module: using custom nu BRs:" << std::endl;
+    for (unsigned int i=0; i<fNuFlavBR.size(); i++){
+      std::cout << "  fNuFlavBR("<< i << "):" << fNuFlavBR.at(i) << std::endl;
+    }
+  }
 
   return;
 }
@@ -180,44 +237,44 @@ std::vector<simb::MCParticle> evgen::NuEScatterGen::GenerateEventKinematics(bool
   int flav = 0;
   double Enu = 0;
 
-  double totNueE   = fNueE  ->Integral(fMinEnu,fMaxEnu,1e-2);
-  double totNumuE  = fNumuE ->Integral(fMinEnu,fMaxEnu,1e-2);
-  double totNutauE = fNutauE->Integral(fMinEnu,fMaxEnu,1e-2);
-  double totNuebarE   = fNuebarE  ->Integral(fMinEnu,fMaxEnu,1e-2);
-  double totNumubarE  = fNumubarE ->Integral(fMinEnu,fMaxEnu,1e-2);
-  double totNutaubarE = fNutaubarE->Integral(fMinEnu,fMaxEnu,1e-2);
-  double tot = totNueE + totNumuE + totNutauE +
-               totNuebarE + totNumubarE + totNutaubarE;
-
   double randflav = fRand->Uniform(0,1);
-  if (randflav < totNueE/tot){
+  if (randflav < fSubtotBR.at(0)){
     flav = 12;
-    Enu = fNueE->GetRandom(fMinEnu,fMaxEnu);
+    if(!fFlatESpectrum)Enu = fNueE->GetRandom(fMinEnu,fMaxEnu);
   }
-  else if (randflav < (totNueE+totNumuE)/tot){
+  else if (randflav < fSubtotBR.at(1)){
     flav = 14;
-    Enu = fNumuE->GetRandom(fMinEnu,fMaxEnu);
+    if(!fFlatESpectrum)Enu = fNumuE->GetRandom(fMinEnu,fMaxEnu);
   }
-  else if (randflav < (totNueE+totNumuE+totNutauE)/tot){
+  else if (randflav < fSubtotBR.at(2)){
     flav = 16;
-    Enu = fNutauE->GetRandom(fMinEnu,fMaxEnu);
+    if(!fFlatESpectrum)Enu = fNutauE->GetRandom(fMinEnu,fMaxEnu);
   }
-  else if (randflav < (totNueE+totNumuE+totNutauE+totNuebarE)/tot){
+  else if (randflav < fSubtotBR.at(3)){
     flav = -12;
-    Enu = fNuebarE->GetRandom(fMinEnu,fMaxEnu);
+    if(!fFlatESpectrum)Enu = fNuebarE->GetRandom(fMinEnu,fMaxEnu);
   }
-  else if (randflav < (totNueE+totNumuE+totNutauE+totNuebarE+totNumubarE)/tot){
+  else if (randflav < fSubtotBR.at(4)){
     flav = -14;
-    Enu = fNumubarE->GetRandom(fMinEnu,fMaxEnu);
+    if(!fFlatESpectrum)Enu = fNumubarE->GetRandom(fMinEnu,fMaxEnu);
   }
   else{
     flav = -16;
-    Enu = fNutaubarE->GetRandom(fMinEnu,fMaxEnu);
+    if(!fFlatESpectrum)Enu = fNutaubarE->GetRandom(fMinEnu,fMaxEnu);
   }
+  if(fFlatESpectrum)Enu = fRand->Uniform(fMinEnu,fMaxEnu);
 
+  // Use specified direction from fcl file:
+  if(fUseFixedDirection){
+    fNuDir.SetX(fXDir);
+    fNuDir.SetY(fYDir);
+    fNuDir.SetZ(fZDir);
+    
+    fNuDir.SetMag(1.0);
+  }
   // Throw a random neutrino direction if we're not generating events for
   // a supernova.  Then, generate a neutrino direction only once / supernova
-  if (fNuDir.Mag() == 0 || !fIsSupernova || isNewNu){
+  else if (fNuDir.Mag() == 0 || !fIsSupernova || isNewNu){
     double nuCos = fRand->Uniform(-1,1);
     double nuPhi = fRand->Uniform(0,2*TMath::Pi());
     fNuDir.SetX(sqrt(1-nuCos*nuCos)*sin(nuPhi));
@@ -234,6 +291,9 @@ std::vector<simb::MCParticle> evgen::NuEScatterGen::GenerateEventKinematics(bool
 
   // ga, gv depend on whether we're scattering nue-e or numu/nutau-e
   double ga = abs(flav)==12 ? 0.5 : -0.5;
+  if(flav < 0) {
+    ga *= -1;
+  }
   double gv = abs(flav)==12 ? 2*fWMA+0.5 : 2*fWMA-0.5;
   fdsigdT->SetParameter(0,gv);
   fdsigdT->SetParameter(1,ga);
@@ -277,6 +337,7 @@ std::vector<simb::MCParticle> evgen::NuEScatterGen::GenerateEventKinematics(bool
   simb::MCParticle mcNu(0, flav, "primary", 0, 0, 1);
   mcNu.AddTrajectoryPoint(vtx, nu4d);
   simb::MCParticle mcE(1, 11, "primary", 0, eMass, 1);
+  mcNu.AddDaughter(mcE.TrackId());
   mcE.AddTrajectoryPoint(vtx, e4d);
 
   std::vector<simb::MCParticle> ret;


### PR DESCRIPTION
provided new versions of services for generating unique noise per channel.  Current version of channel noise service reuses noise waveforms form a pre-generated pool of waveforms.  This leads to correlations that may have undesirable effects for ML training.  The versions of modules and services provided in this PR addresses this issue.  There is also a updated version of NuEScatterGen in this PR that includes fixes from James (Jieran) Shen and some updates that allow specifying custom BRs per flavor and a simpler way to generate a flat energy spectrum.