### PR TITLE
Enable UseModLarqlRecomb as requested by Laura

### DIFF
--- a/dunesim/Simulation/simulationservices_dune.fcl
+++ b/dunesim/Simulation/simulationservices_dune.fcl
@@ -14,6 +14,7 @@ dunefd_largeantparameters.UseLitePhotons: true
 
 #FD2-VD
 dunefdvd_largeantparameters: @local::dunefd_largeantparameters
+dunefdvd_largeantparameters.UseModLarqlRecomb: true
 
 protodune_largeantparameters:   @local::standard_largeantparameters
 protodune_largeantparameters.UseCustomPhysics: true


### PR DESCRIPTION
This is needed to get the correct LY for the region between the field cage and cryostat wall (where the membrane photon detectors are located) (From Laura below)