### PR TITLE
Update dunevd larg4 detector service 

### DIFF
--- a/dunesim/LArG4/IonAndScint_dune.fcl
+++ b/dunesim/LArG4/IonAndScint_dune.fcl
@@ -15,9 +15,6 @@ dunefd_ionandscint_nest.ISCalcAlg: "NEST"
 dunefd_ionandscint_separate: @local::dunefd_ionandscint_correlated
 dunefd_ionandscint_separate.ISCalcAlg: "Separate"
 
-dunefd_ionandscint_larql: @local::dunefd_ionandscint_correlated
-dunefd_ionandscint_larql.services.LArG4Parameters.UseModLarqlRecomb: true
-
 # Choose *the* IonAndScint configuration
 dunefd_ionandscint: @local::dunefd_ionandscint_correlated
 
@@ -26,10 +23,10 @@ dunefd_ionandscint: @local::dunefd_ionandscint_correlated
 dunefdvd_ionandscint: @local::dunefd_ionandscint
 dunefdvd_ionandscint.Instances: "LArG4DetectorServicevolTPCActive"
 # external laterals volume - Semi-analytical model
-dunefdvd_ionandscint_external: @local::dunefd_ionandscint_larql
+dunefdvd_ionandscint_external: @local::dunefd_ionandscint #larql is set in FDVD services
 dunefdvd_ionandscint_external.Instances: "LArG4DetectorServicevolCryostat"
 # Config for ANN: The computable graph already includes the TPC and external laterals volumes
-dunefdvd_ionandscint_ann: @local::dunefd_ionandscint_larql
+dunefdvd_ionandscint_ann: @local::dunefd_ionandscint
 dunefdvd_ionandscint_ann.Instances: "LArG4DetectorServicevolTPCActive;LArG4DetectorServicevolCryostat"
 
 
@@ -64,14 +61,11 @@ protodunehd_ionandscint_nest.ISCalcAlg: "NEST"
 protodunehd_ionandscint_separate: @local::protodunehd_ionandscint_correlated
 protodunehd_ionandscint_separate.ISCalcAlg: "Separate"
 
-protodunehd_ionandscint_larql: @local::protodunehd_ionandscint_correlated
-protodunehd_ionandscint_larql.services.LArG4Parameters.UseModLarqlRecomb: true
-
 # active volume
 protodunehd_ionandscint: @local::protodunehd_ionandscint_separate
 protodunehd_ionandscint.Instances: "LArG4DetectorServicevolTPCActiveInner"
 # external laterals volume
-protodunehd_ionandscint_external: @local::protodunehd_ionandscint_larql
+protodunehd_ionandscint_external: @local::protodunehd_ionandscint
 protodunehd_ionandscint_external.Instances: "LArG4DetectorServicevolTPCActiveOuter"
 
 ##
@@ -87,6 +81,6 @@ protodunevd_ionandscint_separate: @local::protodunevd_ionandscint_correlated
 protodunevd_ionandscint_separate.ISCalcAlg: "Separate"
 
 # Choose *the* IonAndScint configuration
-protodunevd_ionandscint: @local::protodunevd_ionandscint_separate
+protodunevd_ionandscint: @local::protodunevd_ionandscint_correlated
 
 END_PROLOG

--- a/dunesim/LArG4/IonAndScint_dune.fcl
+++ b/dunesim/LArG4/IonAndScint_dune.fcl
@@ -27,10 +27,10 @@ dunefdvd_ionandscint: @local::dunefd_ionandscint
 dunefdvd_ionandscint.Instances: "LArG4DetectorServicevolTPCActive"
 # external laterals volume - Semi-analytical model
 dunefdvd_ionandscint_external: @local::dunefd_ionandscint_larql
-dunefdvd_ionandscint_external.Instances: "LArG4DetectorServicevolExternalActive"
+dunefdvd_ionandscint_external.Instances: "LArG4DetectorServicevolCryostat"
 # Config for ANN: The computable graph already includes the TPC and external laterals volumes
 dunefdvd_ionandscint_ann: @local::dunefd_ionandscint_larql
-dunefdvd_ionandscint_ann.Instances: "LArG4DetectorServicevolTPCActive; LArG4DetectorServicevolExternalActive"
+dunefdvd_ionandscint_ann.Instances: "LArG4DetectorServicevolTPCActive;LArG4DetectorServicevolCryostat"
 
 
 ##
@@ -78,7 +78,7 @@ protodunehd_ionandscint_external.Instances: "LArG4DetectorServicevolTPCActiveOut
 # ProtoDUNE-VD
 ##
 protodunevd_ionandscint_correlated: @local::protodune_ionandscint_correlated
-protodunevd_ionandscint_correlated.Instances:    "LArG4DetectorServicevolTPCActive"
+protodunevd_ionandscint_correlated.Instances:    "LArG4DetectorServicevolTPCActive;LArG4DetectorServicevolCryostat"
 
 protodunevd_ionandscint_nest: @local::protodunevd_ionandscint_correlated
 protodunevd_ionandscint_nest.ISCalcAlg: "NEST"

--- a/dunesim/Simulation/larg4services_dune.fcl
+++ b/dunesim/Simulation/larg4services_dune.fcl
@@ -198,7 +198,7 @@ dunevd10kt_1x8x14_3view_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x14_3view_geo.GDML
-    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
@@ -214,7 +214,7 @@ dunevd10kt_1x8x14_2view_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x14_2view_geo.GDML
-    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
@@ -222,7 +222,7 @@ dunevd10kt_1x8x14backup_3view_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x14backup_3view_geo.GDML
-    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
@@ -230,7 +230,7 @@ dunevd10kt_1x8x6_3view_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x6_3view_geo.GDML
-    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
@@ -238,7 +238,7 @@ dunevd10kt_1x8x6_3view_30deg_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x6_3view_30deg_geo.GDML
-    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
@@ -246,7 +246,7 @@ dunevd10kt_1x8x6_2view_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x6_2view_geo.GDML
-    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 

--- a/dunesim/Simulation/larg4services_dune.fcl
+++ b/dunesim/Simulation/larg4services_dune.fcl
@@ -198,7 +198,7 @@ dunevd10kt_1x8x14_3view_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x14_3view_geo.GDML
-    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
@@ -206,7 +206,7 @@ dunevd10kt_1x8x14_3view_30deg_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x14_3view_30deg_geo.GDML
-    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
@@ -214,7 +214,7 @@ dunevd10kt_1x8x14_2view_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x14_2view_geo.GDML
-    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
@@ -222,7 +222,7 @@ dunevd10kt_1x8x14backup_3view_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x14backup_3view_geo.GDML
-    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
@@ -230,7 +230,7 @@ dunevd10kt_1x8x6_3view_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x6_3view_geo.GDML
-    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
@@ -238,7 +238,7 @@ dunevd10kt_1x8x6_3view_30deg_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x6_3view_30deg_geo.GDML
-    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
@@ -246,7 +246,7 @@ dunevd10kt_1x8x6_2view_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dunevd10kt_1x8x6_2view_geo.GDML
-    volumeNames   : ["volTPCActive", "volExternalActive"] # list of volumes for which the stepLimit should be set
+    volumeNames   : ["volTPCActive", "volCryostat"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4]            # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 


### PR DESCRIPTION
Change the dunevd larg4 detector service parameters from volExternalActive, to volCryostat, in order to simulate energy deposits in the full liquid argon volume. This PR is related with a PR in dunecore: https://github.com/DUNE/dunecore/pull/61