### PR TITLE
HD production changes (replaces PR: https://github.com/DUNE/dunesim/pull/33) 

### DIFF
--- a/dunesim/Simulation/larg4services_dune.fcl
+++ b/dunesim/Simulation/larg4services_dune.fcl
@@ -118,8 +118,11 @@ dune_particle_list_action:
                              # --- This forces that true penultimate point to be saved, thus preserving the info
 }
 
-dunefdvd_particle_list_action: @local::dune_particle_list_action
-dunefdvd_particle_list_action.keepEMShowerDaughters: false  #roll up the shower children into the primary parent
+dunefd_particle_list_action: @local::dune_particle_list_action
+dunefd_particle_list_action.keepEMShowerDaughters: false  #roll up the shower children into the primary parent
+
+
+dunefdvd_particle_list_action: @local::dunefd_particle_list_action
 
 
 supernova_particle_list_action: @local::dune_particle_list_action

--- a/dunesim/Simulation/simulationservices_dune.fcl
+++ b/dunesim/Simulation/simulationservices_dune.fcl
@@ -6,8 +6,8 @@ BEGIN_PROLOG
 dunefd_largeantparameters:
 {
     @table::standard_largeantparameters
-    LongitudinalDiffusion: 6.2e-9 #cm^2/ns
-    TransverseDiffusion:   1.63e-8 #cm^2/ns 
+    LongitudinalDiffusion: 4.0e-9 #cm^2/ns
+    TransverseDiffusion:   8.8e-9 #cm^2/ns 
 }
 dunefd_larvoxelcalculator:   @local::standard_larvoxelcalculator
 dunefd_largeantparameters.UseLitePhotons: true


### PR DESCRIPTION
This can be merged

 - Use ProtoDUNE values for diffusion.
 - Wirecell will not pick up these values by default; the wirecell fcl in dunereco will need to be updated to point to the diffusion values here.
 - Dedicated dune FD particle list action