### PR TITLE
Remove version for gdml and let geometry_dune.fcl handle that

### DIFF
--- a/dunesim/Simulation/larg4services_dune.fcl
+++ b/dunesim/Simulation/larg4services_dune.fcl
@@ -165,10 +165,10 @@ dune10kt_1x2x2_v4_larg4detector:
     stepLimits    : [0.4, 0.4] # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
-dune10kt_1x2x6_v4_larg4detector:
+dune10kt_1x2x6_larg4detector:
 {
     category      : "world"
-    gdmlFileName_ : @local::dune10kt_1x2x6_v4_refactored_geo.GDML
+    gdmlFileName_ : @local::dune10kt_1x2x6_refactored_geo.GDML
     volumeNames   : ["volTPCActiveInner", "volTPCActiveOuter"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4] # corresponding stepLimits in mm for the volumes in the volumeNames list
 }


### PR DESCRIPTION
LArG4 detector for the 1x2x6 hardcodes the version number into the fcl param name and the value.  Remove the specified versions and let geometry_dune.fcl handle which version to point to.

Needs https://github.com/DUNE/dunecore/pull/79