### PR TITLE
VD buffer region along Z included for marley gen

### DIFF
--- a/dunesim/EventGenerator/marley_dune.fcl
+++ b/dunesim/EventGenerator/marley_dune.fcl
@@ -38,10 +38,10 @@ dune_marley_solar_nue_es_flat.marley_parameters.reactions: ["ES.react" ]
 
 # VD-specific MARLEY configurations to include the region between FC and Cryo wall in the neutrino gen position
 dunevd_marley_nue_cc_flat: @local::dune_marley_nue_cc_flat
-dunevd_marley_nue_cc_flat.vertex: { type: "box"  min_position: [ -327.0, -732.0, 0.0 ]  max_position: [ 375.0, 732.0, 2100.0 ]  check_active: false }
+dunevd_marley_nue_cc_flat.vertex: { type: "box"  min_position: [ -327.0, -732.0, -57.0 ]  max_position: [ 375.0, 732.0, 2157.0 ]  check_active: false }
 
 dunevd_marley_nue_es_flat: @local::dune_marley_nue_es_flat
-dunevd_marley_nue_es_flat.vertex: { type: "box"  min_position: [ -327.0, -732.0, 0.0 ]  max_position: [ 375.0, 732.0, 2100.0 ]  check_active: false }
+dunevd_marley_nue_es_flat.vertex: { type: "box"  min_position: [ -327.0, -732.0, -57.0 ]  max_position: [ 375.0, 732.0, 2157.0 ]  check_active: false }
 
 
 END_PROLOG


### PR DESCRIPTION
Including buffer region in the XY plane for generating marley events in VD (adding to the buffer region along the YZ plane: distance 65cm - 8cm to be consistent with what Pablo has been using in his studies) 