### PR TITLE
A LArG4ParticleFilter fcl config for selecting neutrons with TPC activity

### DIFF
--- a/dunesim/SimFilter/larg4particlefilter_dune.fcl
+++ b/dunesim/SimFilter/larg4particlefilter_dune.fcl
@@ -14,7 +14,7 @@ dunefd_neutrontpcfilter: @local::standard_larg4particlefilter
 dunefd_neutrontpcfilter.InterestingPDGs:                [ 2112 ] # Demand a neutron
 dunefd_neutrontpcfilter.ParticleMinMomentum:            [ -1 ]   # Do not demand a lower momentum bound          
 dunefd_neutrontpcfilter.ParticleMaxMomentum:            [ -1 ]   # Do not demand an upper momentum bound
-dunefd_neutrontpcfilter.StartInTPC:                     [ -1 ]   # Do not demand that the neutron starts in the TPC
+dunefd_neutrontpcfilter.StartInTPC:                     [  0 ]   # Do not demand that the neutron starts in the TPC
 dunefd_neutrontpcfilter.StopInTPC:                      [  1 ]   # DO demand that the neutron stops in the TPC
 dunefd_neutrontpcfilter.ParticleMinTPCLength:           [ -1 ]   # Do not demand that the neutron has a minimum trajectory length in the TPC
 dunefd_neutrontpcfilter.RequireAllInterestingParticles: true

--- a/dunesim/SimFilter/larg4particlefilter_dune.fcl
+++ b/dunesim/SimFilter/larg4particlefilter_dune.fcl
@@ -10,4 +10,12 @@ dune35t_larg4particlefilter.StartInTPC:               [ 0  ,  0  ] # 0: don't ca
 dune35t_larg4particlefilter.StopInTPC:                [ 1  ,  1  ] # 0: don't care if it stops in TPC or not, 1: particle must stop in TPC, 2: particle must not stop in TPC
 dune35t_larg4particlefilter.ParticleMinTPCLength:     [ -1., -1. ] # Minimum particle trajectory length inside of the TPC.  Units are cm.  Negative value means ignore check
 
+dunefd_neutrontpcfilter: @local::standard_larg4particlefilter
+dunefd_neutrontpcfilter.InterestingPDGs:                [ 2112 ] # Demand a neutron
+dunefd_neutrontpcfilter.ParticleMinMomentum:            [ -1 ]   # Do not demand a lower momentum bound          
+dunefd_neutrontpcfilter.ParticleMaxMomentum:            [ -1 ]   # Do not demand an upper momentum bound
+dunefd_neutrontpcfilter.StartInTPC:                     [ -1 ]   # Do not demand that the neutron starts in the TPC
+dunefd_neutrontpcfilter.StopInTPC:                      [  1 ]   # DO demand that the neutron stops in the TPC
+dunefd_neutrontpcfilter.ParticleMinTPCLength:           [ -1 ]   # Do not demand that the neutron has a minimum trajectory length in the TPC
+dunefd_neutrontpcfilter.RequireAllInterestingParticles: true
 END_PROLOG


### PR DESCRIPTION
This PR configures a fcl parameter set for larevt's LArG4ParticleFilter.
This filter selects events in which there is a neutron with TPC activity.  

This configuration relies on geant4 creating a new neutron any time a neutron interacts with a medium, which should be the case.
The filter exploits this and selects any event in which a neutron appears to stop in the TPC.