### PR TITLE
Using larg4det geometry v4 in 1x2x2

### DIFF
--- a/dunesim/EventGenerator/marley_dune.fcl
+++ b/dunesim/EventGenerator/marley_dune.fcl
@@ -4,7 +4,10 @@ BEGIN_PROLOG
 
 # DUNE-specific MARLEY configurations
 dune_marley_monoenergetic: @local::standard_marley_monoenergetic
+
 dune_marley_nue_spectrum: @local::standard_marley_nue_spectrum
+dune_marley_nue_spectrum.marley_parameters.reactions: [ "ve40ArCC_Bhattacharya2009.react", "ES.react" ] 
+
 dune_marley_fermi_dirac: @local::standard_marley_fermi_dirac
 
 dune_marley_flat: @local::standard_marley

--- a/dunesim/Simulation/larg4services_dune.fcl
+++ b/dunesim/Simulation/larg4services_dune.fcl
@@ -165,10 +165,22 @@ protodunevd_drifty_larg4detector:
     stepLimits    : [0.3, 0.3] # corresponding stepLimits in mm for the volumes in the volumeNames list
 }
 
+# I would drop this and leave only dune10kt_1x2x2_larg4detector
+# but maybe it's better to do it in two steps to prevent build failures
+# and check if it's used somewhere else than dunefd_1x2x2_simulation_services
 dune10kt_1x2x2_v4_larg4detector:
 {
     category      : "world"
     gdmlFileName_ : @local::dune10kt_1x2x2_v4_refactored_geo.GDML
+    volumeNames   : ["volTPCActiveInner", "volTPCActiveOuter"] # list of volumes for which the stepLimit should be set
+    stepLimits    : [0.4, 0.4] # corresponding stepLimits in mm for the volumes in the volumeNames list
+}
+# 
+
+dune10kt_1x2x2_larg4detector:
+{
+    category      : "world"
+    gdmlFileName_ : @local::dune10kt_1x2x2_refactored_geo.GDML
     volumeNames   : ["volTPCActiveInner", "volTPCActiveOuter"] # list of volumes for which the stepLimit should be set
     stepLimits    : [0.4, 0.4] # corresponding stepLimits in mm for the volumes in the volumeNames list
 }


### PR DESCRIPTION
I added the default block `dune10kt_1x2x2_larg4detector`, that features the v6 of the geometry. 

The table `dune10kt_1x2x2_v4_larg4detector` should in my opinion be dropped, but I left it for the moment in case I'm wrong or in case somebody is still using it. I can remove it if you agree it is not needed anymore.