### PR TITLE
Changed adc Nbit to 14, new DAQ standard

### DIFF
--- a/dunesim/DetSim/Tool/test/test_IdealAdcSimulator.cxx
+++ b/dunesim/DetSim/Tool/test/test_IdealAdcSimulator.cxx
@@ -59,7 +59,7 @@ int test_IdealAdcSimulator(bool useExistingFcl) {
     fout << "mytool: {" << endl;
     fout << "  tool_type: IdealAdcSimulator" << endl;
     fout << "  Vsen: 2.0" << endl;
-    fout << "  Nbit: 12" << endl;
+    fout << "  Nbit: 14" << endl;
     fout << "}" << endl;
     fout.close();
   } else {

--- a/dunesim/DetSim/fcl/detsimtools_dune.fcl
+++ b/dunesim/DetSim/fcl/detsimtools_dune.fcl
@@ -10,12 +10,12 @@
 tools.adcsim_ideal: {
   tool_type: IdealAdcSimulator
   Vsen: 1.0
-  Nbit: 12
+  Nbit: 14 # used to be 12
 }
 
 tools.adcsim_noisy: {
    tool_type: NoisyAdcSimulator
    Vsen: 1.0
-   Nbit: 12
+   Nbit: 14 # used to be 12
    Noise:5
 }


### PR DESCRIPTION
Since might people are still using 1D simulation, it would be better if they used the correct ADC range.

Linked to the update of Nbit in wirecell https://github.com/DUNE/dunereco/pull/132, but independent from it. To be decided if this MR can go in before that or if the change should happen in both places in the same dunesw version (maybe better?).

Small note: the pre-existent printout in the test Tool module is not great since values are hardcoded, but maybe it's not really used.