### PR TITLE
PATCH: added back a marley block with a typo for backwards compatibility

### DIFF
--- a/dunesim/EventGenerator/marley_dune.fcl
+++ b/dunesim/EventGenerator/marley_dune.fcl
@@ -86,6 +86,7 @@ dune_marley_nue_es_gkvm: @local::dune_marley_gkvm
 dune_marley_nue_es_gkvm.marley_parameters.reactions: ["ES.react" ]
 
 # this takes into account a typo present in many old configurations, so that they can still be used
+dune_marley_gvkm: @local::dune_marley_gkvm
 dune_marley_nue_es_gvkm: @local::dune_marley_nue_es_gkvm
 dune_marley_nue_cc_gvkm: @local::dune_marley_nue_cc_gkvm
 

--- a/dunesim/EventGenerator/marley_dune.fcl
+++ b/dunesim/EventGenerator/marley_dune.fcl
@@ -85,6 +85,10 @@ dune_marley_nue_cc_gkvm.marley_parameters.reactions: ["ve40ArCC_Bhattacharya2009
 dune_marley_nue_es_gkvm: @local::dune_marley_gkvm
 dune_marley_nue_es_gkvm.marley_parameters.reactions: ["ES.react" ]
 
+# this takes into account a typo present in many old configurations, so that they can still be used
+dune_marley_nue_es_gvkm: @local::dune_marley_nue_es_gkvm
+dune_marley_nue_cc_gvkm: @local::dune_marley_nue_cc_gkvm
+
 ### Garching
 dune_marley_garching: @local::dune_marley_nue_spectrum
 dune_marley_garching.marley_parameters.source: {


### PR DESCRIPTION
Since https://github.com/DUNE/dunesw/pull/174 is not in v10_06_00, the fix of the typo from gvkm to gkvm actually breaks some configurations. 

I just added back the blocks with the typo inheriting from the correct ones, so that no problems should rise.