### PR TITLE
Spack mpd build and test: Updated test environment variable definitions. 

### DIFF
--- a/dunesim/DetSim/Service/test/CMakeLists.txt
+++ b/dunesim/DetSim/Service/test/CMakeLists.txt
@@ -8,7 +8,8 @@ cet_transitive_paths(FHICL_DIR BINARY IN_TREE)
 cet_test_env_prepend(FHICL_FILE_PATH "." ${TRANSITIVE_PATHS_WITH_FHICL_DIR})
 cet_transitive_paths(LIBRARY_DIR BINARY IN_TREE)
 cet_test_env_prepend(CET_PLUGIN_PATH ${TRANSITIVE_PATHS_WITH_LIBRARY_DIR})
-cet_test_env_prepend(FW_SEARCH_PATH ${dunecore_BINARY_DIR}/gdml)
+cet_test_env_prepend(FW_SEARCH_PATH ${PROJECT_BINARY_DIR}/../dunecore/gdml)
+cet_test_env_prepend(ROOT_LIBRARY_PATH ${PROJECT_BINARY_DIR}/lib)
 
 MESSAGE( STATUS "CMAKE_LIBRARY_PATH: " ${CMAKE_LIBRARY_PATH} )
 


### PR DESCRIPTION
Use CMake variables that exist to define test environment vars